### PR TITLE
replace version ranges with lockdown version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,13 +54,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>[1.2.1, 1.3.0)</version>
+      <version>1.2.5</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>[1.2.1, 1.3.0)</version>
+      <version>1.2.5</version>
       <scope>runtime</scope>
       <classifier>native</classifier>
     </dependency>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jnr-x86asm</artifactId>
-      <version>[1.0.2,)</version>
+      <version>1.0.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
maven is reproducible when there are not version ranges in play. these artifact with version ranges I see anytime I am using the jruby maven artifact since maven tries to take the latest version today. so any new version might break my project because it was tested against another version. basically the drama of time before bundler.
