### PR TITLE
Guava #1505: NoClassDefFoundError loading Finalizer$ShutDown

### DIFF
--- a/src/main/java/jnr/ffi/util/ref/internal/Finalizer.java
+++ b/src/main/java/jnr/ffi/util/ref/internal/Finalizer.java
@@ -123,20 +123,23 @@ public class Finalizer extends Thread {
   @SuppressWarnings("InfiniteLoopStatement")
   @Override
   public void run() {
-    try {
-      while (true) {
-        try {
-          cleanUp(queue.remove());
-        } catch (InterruptedException e) { /* ignore */ }
-      }
-    } catch (ShutDown shutDown) { /* ignore */ }
+    while (true) {
+      try {
+        if (!cleanUp(queue.remove())) {
+          break;
+        }
+      } catch (InterruptedException e) { /* ignore */ }
+    }
   }
 
   /**
    * Cleans up a single reference. Catches and logs all throwables.
    */
-  private void cleanUp(Reference<?> reference) throws ShutDown {
+  private boolean cleanUp(Reference<?> reference) {
     Method finalizeReferentMethod = getFinalizeReferentMethod();
+    if (finalizeReferentMethod == null) {
+      return false;
+    }
     do {
       /*
        * This is for the benefit of phantom references. Weak and soft
@@ -149,7 +152,7 @@ public class Finalizer extends Thread {
          * The client no longer has a reference to the
          * FinalizableReferenceQueue. We can stop.
          */
-        throw new ShutDown();
+        return false;
       }
 
       try {
@@ -163,12 +166,13 @@ public class Finalizer extends Thread {
        * CPU looking up the Method over and over again.
        */
     } while ((reference = queue.poll()) != null);
+    return true;
   }
 
   /**
    * Looks up FinalizableReference.finalizeReferent() method.
    */
-  private Method getFinalizeReferentMethod() throws ShutDown {
+  private Method getFinalizeReferentMethod() {
     Class<?> finalizableReferenceClass
         = finalizableReferenceClassReference.get();
     if (finalizableReferenceClass == null) {
@@ -180,7 +184,7 @@ public class Finalizer extends Thread {
        * much just shut down and make sure we don't keep it alive any longer
        * than necessary.
        */
-      throw new ShutDown();
+      return null;
     }
     try {
       return finalizableReferenceClass.getMethod("finalizeReferent");
@@ -202,8 +206,4 @@ public class Finalizer extends Thread {
       return null;
     }
   }
-
-  /** Indicates that it's time to shut down the Finalizer. */
-  @SuppressWarnings("serial") // Never serialized or thrown out of this class.
-  private static class ShutDown extends Exception { }
 }


### PR DESCRIPTION
Get rid of the `ShutDown` nested class. Confirmed that this fixes [JENKINS-19192](https://issues.jenkins-ci.org/browse/JENKINS-19192).

[Guava #1505](https://code.google.com/p/guava-libraries/issues/detail?id=1505)
