### PR TITLE
Add an annotation for explicit struct packing

### DIFF
--- a/libtest/PackedStructTest.c
+++ b/libtest/PackedStructTest.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2007 Wayne Meissner. All rights reserved.
+ *
+ * This file is part of jffi.
+ *
+ * This code is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * version 3 along with this work.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#pragma pack(push, 2)
+struct pack2  {
+    uint32_t i;
+    uint64_t l;
+};
+
+struct pack2_small {
+    uint8_t tiny;
+    uint8_t tiny2;
+    uint32_t deadbeef;
+};
+#pragma pack(pop)
+
+struct pack2*
+packedstruct_make_struct(uint32_t i, uint64_t l)
+{
+    static struct pack2 s;
+    memset(&s, 0, sizeof(s));
+    s.i = i;
+    s.l = l;
+    return &s;
+}
+
+struct pack2_small*
+packedstruct_make_tiny(uint8_t v1, uint8_t v2)
+{
+    static struct pack2_small s;
+    memset(&s, 0, sizeof(s));
+    s.tiny = v1;
+    s.tiny2 = v2;
+    s.deadbeef = 0xdeadbeef;
+    return &s;
+}

--- a/src/main/java/jnr/ffi/annotations/Pack.java
+++ b/src/main/java/jnr/ffi/annotations/Pack.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2011 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.ffi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Explicitly specifies the packing for structure fields.
+ *
+ * Using this annation means that each field in the structure will be
+ * padded by at most {@code padding} bytes, rather than using the default
+ * compiler packing strategy. This is analogous to the {@code pragma pack}
+ * C compiler pragma. It should be used with great caution.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(value = { ElementType.TYPE })
+public @interface Pack {
+    public int padding();
+}

--- a/src/test/java/jnr/ffi/struct/PackedStructTest.java
+++ b/src/test/java/jnr/ffi/struct/PackedStructTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2008 Wayne Meissner
+ *
+ * This file is part of jffi.
+ *
+ * This code is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License version 3 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ * version 3 for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * version 3 along with this work.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package jnr.ffi.struct;
+
+import static org.junit.Assert.assertEquals;
+
+import jnr.ffi.annotations.Pack;
+import jnr.ffi.Struct;
+import jnr.ffi.TstUtil;
+import jnr.ffi.types.u_int32_t;
+import jnr.ffi.types.u_int64_t;
+import jnr.ffi.types.u_int8_t;
+import jnr.ffi.Runtime;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for explicitly packed structures.
+ */
+public class PackedStructTest {
+    static TestLib testlib;
+    static Runtime runtime;
+
+    public PackedStructTest() {
+    }
+
+    @Pack(padding = 2)
+    public static class Pack2 extends Struct {
+        public final u_int32_t i = new u_int32_t();
+        public final u_int64_t l = new u_int64_t();
+        public Pack2(Runtime runtime) {
+            super(runtime);
+        }
+    }
+
+    @Pack(padding = 2)
+    public static class Pack2Small extends Struct {
+        public final u_int8_t v1 = new u_int8_t();
+        public final u_int8_t v2 = new u_int8_t();
+        // Intentionally ignoring sentinel "deadbeef" field
+        public Pack2Small(Runtime runtime) {
+            super(runtime);
+        }
+    }
+
+    public static interface TestLib {
+        Pack2 packedstruct_make_struct(@u_int32_t int i, @u_int64_t long l);
+        Pack2Small packedstruct_make_tiny(@u_int8_t byte v1, @u_int8_t byte v2);
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        testlib = TstUtil.loadTestLib(TestLib.class);
+        runtime = Runtime.getRuntime(testlib);
+    }
+
+    @Test
+    public void testPackedStructureAlignment() {
+        final int i = 0xAAAAAAAA;
+        final long l = 0xBBBBBBBBBBBBBBBBL;
+        Pack2 p = testlib.packedstruct_make_struct(i, l);
+        assertEquals("Incorrect int value in struct", i, p.i.get());
+        assertEquals("Incorrect long value in struct", l, p.l.get());
+    }
+
+    /**
+     * Tests that fields that have natural alignment smaller than the
+     * maximum packing value aren't artifically expanded.
+     */
+    @Test
+    public void testFieldsSmallerThanPacking() {
+        final byte v1 = 0xA;
+        final byte v2 = 0xB;
+        Pack2Small p = testlib.packedstruct_make_tiny(v1, v2);
+        assertEquals("Incorrect byte value 1 in struct", v1, p.v1.get());
+        assertEquals("Incorrect byte value 1 in struct", v2, p.v2.get());
+    }
+}


### PR DESCRIPTION
Library headers on some platforms may use the #pack pragma to control
structure field packing for parameters of public methods. This patch
adds a @Pack annotation that mimics this functionality on a
structure-by-structure basis, allowing use of jnr-ffi with such
libraries.

Closes #8