### PR TITLE
Fix stat.st_gid on FreeBSD 10

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/NativeLibrary.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeLibrary.java
@@ -92,7 +92,7 @@ public class NativeLibrary {
         return Collections.unmodifiableList(libs);
     }
 
-    private static final Pattern BAD_ELF = Pattern.compile("(.*): invalid ELF header");
+    private static final Pattern BAD_ELF = Pattern.compile("(.*): (invalid ELF header|file too short|invalid file format)");
     private static final Pattern ELF_GROUP = Pattern.compile("GROUP\\s*\\(\\s*(\\S*).*\\)");
 
     private static com.kenai.jffi.Library openLibrary(String path) {

--- a/src/main/java/jnr/ffi/provider/jffi/NativeLibrary.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeLibrary.java
@@ -109,7 +109,7 @@ public class NativeLibrary {
             File f = new File(badElf.group(1));
             if (f.isFile() && f.length() < (4 * 1024)) {
                 Matcher sharedObject = ELF_GROUP.matcher(readAll(f));
-                if (sharedObject.lookingAt()) {
+                if (sharedObject.find()) {
                     return com.kenai.jffi.Library.getCachedInstance(sharedObject.group(1), com.kenai.jffi.Library.LAZY | com.kenai.jffi.Library.GLOBAL);
                 }
             }


### PR DESCRIPTION
FreeBSD 10 has an ld script for /usr/lib/libc.so. It is reported as "invalid file format", and not "invalid ELF header". Moreover it starts with a comment, which prevents the current regex to properly match the GROUP clause.

https://github.com/ffi/ffi/issues/308