### PR TITLE
Corrects the handling of function mappers, addressing jnr/jnr-ffi#13.

### DIFF
--- a/src/main/java/jnr/ffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/LibraryLoader.java
@@ -177,11 +177,11 @@ public abstract class LibraryLoader<T> {
      * Multiple function mappers can be specified by additional calls to this method, and
      * each mapper will be tried in order, until one is successful.
      *
-     * @param typeMapper The function mapper to use.
+     * @param functionMapper The function mapper to use.
      * @return The {@code LibraryLoader} instance.
      */
-    public LibraryLoader<T> mapper(FunctionMapper typeMapper) {
-        optionMap.put(LibraryOption.FunctionMapper, typeMapper);
+    public LibraryLoader<T> mapper(FunctionMapper functionMapper) {
+        functionMappers.add(functionMapper);
         return this;
     }
 

--- a/src/main/java/jnr/ffi/mapper/CompositeFunctionMapper.java
+++ b/src/main/java/jnr/ffi/mapper/CompositeFunctionMapper.java
@@ -18,11 +18,11 @@ public final class CompositeFunctionMapper implements FunctionMapper {
     public String mapFunctionName(String functionName, Context context) {
         for (FunctionMapper functionMapper : functionMappers) {
             String mappedName = functionMapper.mapFunctionName(functionName, context);
-            if (mappedName != null) {
+            if (mappedName != functionName) {
+                // A translation was explicit in this mapper.
                 return mappedName;
             }
         }
-
-        return null;
+        return functionName;
     }
 }

--- a/src/main/java/jnr/ffi/mapper/FunctionMapper.java
+++ b/src/main/java/jnr/ffi/mapper/FunctionMapper.java
@@ -34,8 +34,17 @@ public interface FunctionMapper {
         public abstract boolean isSymbolPresent(String name);
         public Collection<Annotation> getAnnotations();
     }
-    public String mapFunctionName(String functionName, Context context);
 
+    /**
+     * Translate the (Java) function name into its (native) equivalent. If the
+     * name is not present in the map, it is to return the supplied name (same
+     * object exactly).
+     *
+     * @param functionName to translate
+     * @param context for translation
+     * @return native equivalent or <code>functionName</code> if not in map
+     */
+    public String mapFunctionName(String functionName, Context context);
 
     public static final class Builder {
         private final Map<String, String> functionNameMap = Collections.synchronizedMap(new HashMap<String, String>());

--- a/src/test/java/jnr/ffi/LibraryLoaderTest.java
+++ b/src/test/java/jnr/ffi/LibraryLoaderTest.java
@@ -1,33 +1,131 @@
 package jnr.ffi;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import jnr.ffi.mapper.FunctionMapper;
+import jnr.ffi.provider.FFIProvider;
+
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class LibraryLoaderTest {
+
     public static interface TestLib {
         int setLastError(int error);
     }
 
     @Test public void loadShouldNotThrowExceptions() {
         try {
-            LibraryLoader.create(TestLib.class).load("non-existant-library");
+            LibraryLoader.create(TestLib.class).load("non-existent-library");
         } catch (Throwable t) {
             fail("load raised exception " + t);
         }
     }
-    
+
     @Test(expected = UnsatisfiedLinkError.class)
     public void failImmediatelyShouldThrowULE() {
-        LibraryLoader.create(TestLib.class).failImmediately().load("non-existant-library");
+        LibraryLoader.create(TestLib.class).failImmediately().load("non-existent-library");
     }
 
     @Test(expected = UnsatisfiedLinkError.class)
     public void invocationOnFailedLoadShouldThrowULE() {
-        TestLib lib = LibraryLoader.create(TestLib.class).failImmediately().load("non-existant-library");
+        TestLib lib = LibraryLoader.create(TestLib.class).failImmediately().load("non-existent-library");
         lib.setLastError(0);
+    }
+
+    // Loadable library interface to test function mapping
+    public static interface TestLibMapped {
+        int set(int error);
+    }
+
+    @Test
+    public void optionWithFunctionMapper() {
+        LibraryLoader<TestLibMapped> loader = FFIProvider.getSystemProvider()
+                .createLibraryLoader(TestLibMapped.class);
+        loader.library("test");
+
+        // Define function mappings by a FunctionMapper entry in options
+        FunctionMapper.Builder shortNames = new FunctionMapper.Builder();
+        shortNames.map("set", "setLastError");
+        loader.option(LibraryOption.FunctionMapper, shortNames.build());
+
+        // Load and call the mapped function
+        TestLibMapped lib = loader.load();
+        lib.set(1);
+    }
+
+    @Test
+    public void mapperWithFuctionMapper() {
+        LibraryLoader<TestLibMapped> loader = FFIProvider.getSystemProvider()
+                .createLibraryLoader(TestLibMapped.class);
+        loader.library("test");
+
+        // Define function mappings via the type-safe API
+        FunctionMapper.Builder shortNames = new FunctionMapper.Builder();
+        shortNames.map("set", "setLastError");
+        loader.mapper(shortNames.build());
+
+        // Load and call the mapped function
+        TestLibMapped lib = loader.load();
+        lib.set(2);
+    }
+
+    @Test
+    public void mapMethod() {
+        LibraryLoader<TestLibMapped> loader = FFIProvider.getSystemProvider()
+                .createLibraryLoader(TestLibMapped.class);
+        loader.library("test");
+
+        // Define function mappings via the String API
+        loader.map("set", "setLastError");
+
+        // Load and call the mapped function
+        TestLibMapped lib = loader.load();
+        lib.set(3);
+    }
+
+    // Loadable library interface to test complicated function mapping
+    public static interface TestLibMath {
+        public int add(int i1, int i2); // = add_int32_t
+        public int sub(int i1, int i2); // = sub_int32_t
+        public int mul(int i1, int i2); // = mul_int32_t
+        public int div(int i1, int i2); // = div_int32_t
+        public double addd(double f1, double f2); // = add_double
+        public double subd(double f1, double f2); // = add_double
+    }
+
+    @Test
+    public void functionMappersCombine() {
+        LibraryLoader<TestLibMath> loader = FFIProvider.getSystemProvider()
+                .createLibraryLoader(TestLibMath.class);
+        loader.library("test");
+
+        // Define function mappings by a FunctionMapper entry in options
+        FunctionMapper.Builder shortNames = new FunctionMapper.Builder();
+        shortNames.map("add", "add_int32_t");
+        shortNames.map("sub", "sub_int32_t");
+        loader.option(LibraryOption.FunctionMapper, shortNames.build());
+
+        // Define function mappings via the type-safe API
+        shortNames = new FunctionMapper.Builder();
+        shortNames.map("mul", "mul_int32_t");
+        shortNames.map("div", "div_int32_t");
+        loader.mapper(shortNames.build());
+
+        // Define function mappings via the String API
+        loader.map("addd", "add_double");
+        loader.map("subd", "sub_double");
+
+        TestLibMath lib = loader.load();
+        assertNotNull("Could not load libtest", lib);
+
+        // Do some arithmetic with the library to prove methods exist
+        int sum = lib.sub(lib.add(10, 5), 3); // 10+5-3 = 12
+        int prod = lib.mul(sum, 7);
+        int answer = lib.div(prod, 2);
+        assertEquals(answer, 42);
+
+        double a = lib.subd(lib.addd(30.0, 20.0), 8.0);
+        assertEquals(a, 42.0, 1e-4);
     }
 }


### PR DESCRIPTION
LibraryLoader now uses its functionMappers member in line with the
design. The contract of FunctionMapper.mapFunctionName is made
explicit and a bug fixed in CompositeFunctionMapper. Tests are added
to LibraryLoaderTest.
