### PR TITLE
[FIXES JENKINS-20276] bestMatch should reflect the search path priority

### DIFF
--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -452,8 +452,10 @@ public abstract class Platform {
                 } else {
                     String num = path.substring(path.lastIndexOf(".so.") + 4);
                     try {
-                        if (Integer.parseInt(num) >= version) {
+                        int v = Integer.parseInt(num);
+                        if (v > version) {
                             bestMatch = path;
+                            version = v;
                         }
                     } catch (NumberFormatException e) {
                     } // Just skip if not a number


### PR DESCRIPTION
- The search path may contain multiple matches of the same version
- For example if the search path is `/usr/lib64:/lib64:/lib:/usr/lib` you can get
  `/lib64/libc.so.6` and `/lib/libc.so.6`, since this is a path, the first
  should win, but because version is always 0 what actually happens is the last
  best match wins.

See [JENKINS-20276](https://issues.jenkins-ci.org/browse/JENKINS-20276) for an example