### PR TITLE
Select first match instead of last when searching for maximum version of .so file on linux

### DIFF
--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -457,7 +457,7 @@ public abstract class Platform {
                         continue; // Just skip if not a number
                     }
                 }
-                if (fileVersion > bestVersiobestMatch = path;
+                if (fileVersion > bestVersion) {
                     bestMatch = path;
                     bestVersion = fileVersion;
                 }


### PR DESCRIPTION
IMHO the order of the libraryPath is important and libraries should come from the first location they can be found in.
