### PR TITLE
Fix conversion of parameters of type struct array on 32-bit platforms

### DIFF
--- a/src/main/java/jnr/ffi/provider/converters/StructArrayParameterConverter.java
+++ b/src/main/java/jnr/ffi/provider/converters/StructArrayParameterConverter.java
@@ -51,7 +51,6 @@ public class StructArrayParameterConverter implements ToNativeConverter<Struct[]
     }
 
     @Override
-    @LongLong
     public Class<Pointer> nativeType() {
         return Pointer.class;
     }


### PR DESCRIPTION
The "LongLong" annotation forces a struct array to be converted into a 64-bit pointer, even in 32-bit platforms.

See https://github.com/jnr/jnr-ffi/issues/34#issuecomment-83052969 for more information.