### PR TITLE
Add support for varargs methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-ffi</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.4-SNAPSHOT</version>
+  <version>2.0.4.varargs-SNAPSHOT</version>
   <name>jnr-ffi</name>
   <description>A library for invoking native functions from java</description>
   <url>http://github.com/jnr/jnr-ffi</url>

--- a/src/main/java/jnr/ffi/annotations/Direct.java
+++ b/src/main/java/jnr/ffi/annotations/Direct.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 public @interface Direct {
 
 }

--- a/src/main/java/jnr/ffi/annotations/Encoding.java
+++ b/src/main/java/jnr/ffi/annotations/Encoding.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * Used to specify the {@link java.nio.charset.Charset} to use for encoding/decoding a {@link String}
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(value = { ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE })
+@Target(value = { ElementType.PARAMETER, ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
 public @interface Encoding {
     String value();
 }

--- a/src/main/java/jnr/ffi/annotations/In.java
+++ b/src/main/java/jnr/ffi/annotations/In.java
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.PARAMETER, ElementType.METHOD })
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface In {
 
 }

--- a/src/main/java/jnr/ffi/annotations/Meta.java
+++ b/src/main/java/jnr/ffi/annotations/Meta.java
@@ -18,30 +18,13 @@
 
 package jnr.ffi.annotations;
 
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Indicates that the temporary native memory allocated for an {@code @Out} paramneter
- * should be cleared before passing to the native function.
- *
- * <p>By default, parameters that are annotated as {@code @Out} only do not clear
- * the data in the temporary native memory area allocated when a java heap object
- * is passed in as the parameter, so the memory passed to the native function is
- * full of garbage data.  After the native method returns, the native memory is
- * copied back to java, which is usually not a problem, since the native function
- * will have updated the memory with valid data.  However, if the native function
- * fails, the garbage data that was in the temporary native memory will be copied
- * back to java.
- *
- * @see In
- * @see Out
- */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
-public @interface Clear {
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Meta {
 
 }

--- a/src/main/java/jnr/ffi/annotations/NulTerminate.java
+++ b/src/main/java/jnr/ffi/annotations/NulTerminate.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * before passing it to a native function.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.PARAMETER, ElementType.METHOD })
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface NulTerminate {
 
 }

--- a/src/main/java/jnr/ffi/annotations/Out.java
+++ b/src/main/java/jnr/ffi/annotations/Out.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  * @see Clear
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.PARAMETER, ElementType.METHOD })
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface Out {
 
 }

--- a/src/main/java/jnr/ffi/annotations/Pinned.java
+++ b/src/main/java/jnr/ffi/annotations/Pinned.java
@@ -35,6 +35,6 @@ import java.lang.annotation.Target;
  * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 public @interface Pinned {
 }

--- a/src/main/java/jnr/ffi/annotations/Transient.java
+++ b/src/main/java/jnr/ffi/annotations/Transient.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * and after the method call, the native memory can be freed again.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 public @interface Transient {
 
 }

--- a/src/main/java/jnr/ffi/provider/NativeInvocationHandler.java
+++ b/src/main/java/jnr/ffi/provider/NativeInvocationHandler.java
@@ -43,16 +43,8 @@ public class NativeInvocationHandler implements InvocationHandler {
     }
 
     public Object invoke(Object self, Method method, Object[] argArray) throws Throwable {
-        if (method.isVarArgs()) {
-            Invoker invoker = invokerMap.get(method);
-            if (invoker == null) {
-                throw new UnsatisfiedLinkError("no invoker for native method " + method.getName());
-            }
-            return invoker.invoke(self, argArray);
-        } else {
-            Invoker invoker = fastLookupTable.get(method);
-            return invoker != null ? invoker.invoke(self, argArray) : lookupAndCacheInvoker(method).invoke(self, argArray);
-        }
+        Invoker invoker = fastLookupTable.get(method);
+        return invoker != null ? invoker.invoke(self, argArray) : lookupAndCacheInvoker(method).invoke(self, argArray);
     }
 
     private synchronized Invoker lookupAndCacheInvoker(Method method) {

--- a/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
@@ -19,13 +19,19 @@
 
 package jnr.ffi.provider.jffi;
 
-import com.kenai.jffi.Function;
-import jnr.ffi.*;
-import jnr.ffi.mapper.*;
-import jnr.ffi.provider.*;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.ClassWriter;
+import static jnr.ffi.provider.jffi.CodegenUtils.ci;
+import static jnr.ffi.provider.jffi.CodegenUtils.p;
+import static jnr.ffi.provider.jffi.CodegenUtils.sig;
+import static jnr.ffi.provider.jffi.InvokerUtil.getCallContext;
+import static jnr.ffi.provider.jffi.InvokerUtil.getCallingConvention;
+import static jnr.ffi.provider.jffi.InvokerUtil.getParameterTypes;
+import static jnr.ffi.provider.jffi.InvokerUtil.getResultType;
+import static jnr.ffi.util.Annotations.sortedAnnotationCollection;
+import static org.objectweb.asm.Opcodes.ACC_FINAL;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.V1_6;
 
 import java.io.PrintWriter;
 import java.lang.reflect.Constructor;
@@ -34,10 +40,34 @@ import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static jnr.ffi.provider.jffi.CodegenUtils.*;
-import static jnr.ffi.provider.jffi.InvokerUtil.*;
-import static jnr.ffi.util.Annotations.sortedAnnotationCollection;
-import static org.objectweb.asm.Opcodes.*;
+import jnr.ffi.CallingConvention;
+import jnr.ffi.LibraryOption;
+import jnr.ffi.annotations.Synchronized;
+import jnr.ffi.mapper.CachingTypeMapper;
+import jnr.ffi.mapper.CompositeTypeMapper;
+import jnr.ffi.mapper.DefaultSignatureType;
+import jnr.ffi.mapper.FromNativeContext;
+import jnr.ffi.mapper.FunctionMapper;
+import jnr.ffi.mapper.MethodResultContext;
+import jnr.ffi.mapper.SignatureType;
+import jnr.ffi.mapper.SignatureTypeMapper;
+import jnr.ffi.mapper.SignatureTypeMapperAdapter;
+import jnr.ffi.mapper.TypeMapper;
+import jnr.ffi.provider.IdentityFunctionMapper;
+import jnr.ffi.provider.InterfaceScanner;
+import jnr.ffi.provider.Invoker;
+import jnr.ffi.provider.NativeFunction;
+import jnr.ffi.provider.NativeVariable;
+import jnr.ffi.provider.NullTypeMapper;
+import jnr.ffi.provider.ParameterType;
+import jnr.ffi.provider.ResultType;
+import jnr.ffi.provider.jffi.AsmBuilder.ObjectField;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+
+import com.kenai.jffi.Function;
 
 public class AsmLibraryLoader extends LibraryLoader {
     public final static boolean DEBUG = Boolean.getBoolean("jnr.ffi.compile.dump");
@@ -108,9 +138,16 @@ public class AsmLibraryLoader extends LibraryLoader {
                 new BufferMethodGenerator()
         };
         
+        DefaultInvokerFactory invokerFactory = new DefaultInvokerFactory(runtime, library, typeMapper, functionMapper, libraryCallingConvention, interfaceClass.isAnnotationPresent(Synchronized.class));
         InterfaceScanner scanner = new InterfaceScanner(interfaceClass, typeMapper, libraryCallingConvention);
 
         for (NativeFunction function : scanner.functions()) {
+            if (function.getMethod().isVarArgs()) {
+                ObjectField field = builder.getObjectField(invokerFactory.createInvoker(function.getMethod()), Invoker.class);
+                generateVarargsInvocation(builder, function.getMethod(), field);
+                continue;
+            }
+
             String functionName = functionMapper.mapFunctionName(function.name(), new NativeFunctionMapperContext(library, function.annotations()));
 
             try {
@@ -217,5 +254,106 @@ public class AsmLibraryLoader extends LibraryLoader {
         mv.visitEnd();
     }
 
+    private void generateVarargsInvocation(AsmBuilder builder, Method m, ObjectField field) {
+        Class[] parameterTypes = m.getParameterTypes();
+        SkinnyMethodAdapter mv = new SkinnyMethodAdapter(builder.getClassVisitor(), ACC_PUBLIC | ACC_FINAL,
+                m.getName(),
+                sig(m.getReturnType(), parameterTypes), null, null);
+        mv.start();
 
+        // Retrieve the invoker
+        mv.aload(0);
+        mv.getfield(builder.getClassNamePath(), field.name, ci(Invoker.class));
+
+        //Push ref to this
+        mv.aload(0);
+        
+        //Construct the params array
+        mv.pushInt(parameterTypes.length);
+        mv.anewarray(p(Object.class));
+        
+        int slot = 1;
+        for (int i = 0; i < parameterTypes.length; i++) {
+            mv.dup();
+            mv.pushInt(i);
+            if (parameterTypes[i].equals(long.class)) {
+                mv.lload(slot);
+                mv.invokestatic(Long.class, "valueOf", Long.class, long.class);
+                slot++;
+            } else if (parameterTypes[i].equals(double.class)) {
+                mv.dload(slot);
+                mv.invokestatic(Double.class, "valueOf", Double.class, double.class);
+                slot++;
+            } else if (parameterTypes[i].equals(int.class)) {
+                mv.iload(slot);
+                mv.invokestatic(Integer.class, "valueOf", Integer.class, int.class);
+            } else if (parameterTypes[i].equals(float.class)) {
+                mv.fload(slot);
+                mv.invokestatic(Float.class, "valueOf", Float.class, float.class);
+            } else if (parameterTypes[i].equals(short.class)) {
+                mv.iload(slot);
+                mv.i2s();
+                mv.invokestatic(Short.class, "valueOf", Short.class, short.class);
+            } else if (parameterTypes[i].equals(char.class)) {
+                mv.iload(slot);
+                mv.i2c();
+                mv.invokestatic(Character.class, "valueOf", Character.class, char.class);
+            } else if (parameterTypes[i].equals(byte.class)) {
+                mv.iload(slot);
+                mv.i2b();
+                mv.invokestatic(Byte.class, "valueOf", Byte.class, byte.class);
+            } else if (parameterTypes[i].equals(char.class)) {
+                mv.iload(slot);
+                mv.i2b();
+                mv.invokestatic(Boolean.class, "valueOf", Boolean.class, boolean.class);
+            } else {
+                mv.aload(slot);
+            }
+            mv.aastore();
+            slot++;
+        }
+        
+        // call invoker(this, parameters)
+        mv.invokeinterface(jnr.ffi.provider.Invoker.class, "invoke", Object.class, Object.class, Object[].class);
+        
+        Class<?> returnType = m.getReturnType();
+        if (returnType.equals(long.class)) {
+            mv.checkcast(Long.class);
+            mv.invokevirtual(Long.class, "longValue", long.class);
+            mv.lreturn();
+        } else if (returnType.equals(double.class)) {
+            mv.checkcast(Double.class);
+            mv.invokevirtual(Double.class, "doubleValue", double.class);
+            mv.dreturn();
+        } else if (returnType.equals(int.class)) {
+            mv.checkcast(Integer.class);
+            mv.invokevirtual(Integer.class, "intValue", int.class);
+            mv.ireturn();
+        } else if (returnType.equals(float.class)) {
+            mv.checkcast(Float.class);
+            mv.invokevirtual(Float.class, "floatValue", float.class);
+            mv.freturn();
+        } else if (returnType.equals(short.class)) {
+            mv.checkcast(Short.class);
+            mv.invokevirtual(Short.class, "shortValue", short.class);
+            mv.ireturn();
+        } else if (returnType.equals(char.class)) {
+            mv.checkcast(Character.class);
+            mv.invokevirtual(Character.class, "charValue", char.class);
+            mv.ireturn();
+        } else if (returnType.equals(byte.class)) {
+            mv.checkcast(Byte.class);
+            mv.invokevirtual(Byte.class, "byteValue", byte.class);
+            mv.ireturn();
+        } else if (returnType.equals(boolean.class)) {
+            mv.checkcast(Boolean.class);
+            mv.invokevirtual(Boolean.class, "booleanValue", boolean.class);
+            mv.ireturn();
+        } else {
+            mv.areturn();
+        }
+        
+        mv.visitMaxs(100, AsmUtil.calculateLocalVariableSpace(parameterTypes) + 1);
+        mv.visitEnd();
+    }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
@@ -349,7 +349,10 @@ public class AsmLibraryLoader extends LibraryLoader {
             mv.checkcast(Boolean.class);
             mv.invokevirtual(Boolean.class, "booleanValue", boolean.class);
             mv.ireturn();
+        } else if (void.class.isAssignableFrom(m.getReturnType())) {
+           mv.voidreturn();
         } else {
+            mv.checkcast(m.getReturnType());
             mv.areturn();
         }
         

--- a/src/main/java/jnr/ffi/provider/jffi/DefaultInvokerFactory.java
+++ b/src/main/java/jnr/ffi/provider/jffi/DefaultInvokerFactory.java
@@ -109,6 +109,10 @@ final class DefaultInvokerFactory {
                 resultContext);
         
         FunctionInvoker functionInvoker = getFunctionInvoker(resultType);
+        if (resultType.getFromNativeConverter() != null) {
+            functionInvoker = new ConvertingInvoker(resultType.getFromNativeConverter(), resultType.getFromNativeContext(), functionInvoker);
+        }
+        
         ParameterType[] parameterTypes = getParameterTypes(runtime, typeMapper, method);
         //Allow individual methods to set the calling convention to stdcall
         CallingConvention callingConvention = method.isAnnotationPresent(StdCall.class)
@@ -124,10 +128,6 @@ final class DefaultInvokerFactory {
             Marshaller[] marshallers = new Marshaller[parameterTypes.length];
             for (int i = 0; i < marshallers.length; ++i) {
                 marshallers[i] = getMarshaller(parameterTypes[i]);
-            }
-
-            if (resultType.getFromNativeConverter() != null) {
-                functionInvoker = new ConvertingInvoker(resultType.getFromNativeConverter(), resultType.getFromNativeContext(), functionInvoker);
             }
 
             return new DefaultInvoker(runtime, library, function, functionInvoker, marshallers);

--- a/src/main/java/jnr/ffi/provider/jffi/DefaultInvokerFactory.java
+++ b/src/main/java/jnr/ffi/provider/jffi/DefaultInvokerFactory.java
@@ -18,39 +18,126 @@
 
 package jnr.ffi.provider.jffi;
 
+import static jnr.ffi.provider.jffi.InvokerUtil.getCallContext;
+import static jnr.ffi.provider.jffi.InvokerUtil.getParameterTypes;
+import static jnr.ffi.provider.jffi.InvokerUtil.getResultType;
+import static jnr.ffi.provider.jffi.NumberUtil.getBoxedClass;
+import static jnr.ffi.provider.jffi.NumberUtil.sizeof;
+import static jnr.ffi.util.Annotations.sortedAnnotationCollection;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import jnr.ffi.Address;
+import jnr.ffi.CallingConvention;
+import jnr.ffi.NativeType;
+import jnr.ffi.Pointer;
+import jnr.ffi.Runtime;
+import jnr.ffi.annotations.Meta;
+import jnr.ffi.annotations.StdCall;
+import jnr.ffi.annotations.Synchronized;
+import jnr.ffi.mapper.DataConverter;
+import jnr.ffi.mapper.DefaultSignatureType;
+import jnr.ffi.mapper.FromNativeContext;
+import jnr.ffi.mapper.FromNativeConverter;
+import jnr.ffi.mapper.FunctionMapper;
+import jnr.ffi.mapper.MethodResultContext;
+import jnr.ffi.mapper.SignatureType;
+import jnr.ffi.mapper.SignatureTypeMapper;
+import jnr.ffi.mapper.ToNativeContext;
+import jnr.ffi.mapper.ToNativeConverter;
+import jnr.ffi.mapper.ToNativeType;
+import jnr.ffi.provider.InvocationSession;
+import jnr.ffi.provider.Invoker;
+import jnr.ffi.provider.ParameterType;
+import jnr.ffi.provider.ResultType;
+import jnr.ffi.provider.SigType;
+import jnr.ffi.util.AnnotationProxy;
+
 import com.kenai.jffi.Function;
 import com.kenai.jffi.HeapInvocationBuffer;
 import com.kenai.jffi.ObjectParameterStrategy;
 import com.kenai.jffi.ObjectParameterType;
-import jnr.ffi.Address;
-import jnr.ffi.NativeType;
-import jnr.ffi.Pointer;
-import jnr.ffi.Runtime;
-import jnr.ffi.mapper.*;
-import jnr.ffi.provider.*;
-
-import java.lang.annotation.Annotation;
-import java.nio.*;
-import java.util.Collection;
-
-import static jnr.ffi.provider.jffi.NumberUtil.getBoxedClass;
-import static jnr.ffi.provider.jffi.NumberUtil.sizeof;
 
 final class DefaultInvokerFactory {
+    private final Runtime runtime;
+    private final NativeLibrary library;
+    private final SignatureTypeMapper typeMapper;
+    private final FunctionMapper functionMapper;
+    private final jnr.ffi.CallingConvention libraryCallingConvention;
+    private final boolean libraryIsSynchronized;
 
-    final jnr.ffi.provider.Invoker createInvoker(jnr.ffi.Runtime runtime, NativeLibrary nativeLibrary, Function function, ResultType resultType, ParameterType[] parameterTypes) {
+    public DefaultInvokerFactory(
+            Runtime runtime,
+            NativeLibrary library,
+            SignatureTypeMapper typeMapper,
+            FunctionMapper functionMapper,
+            CallingConvention libraryCallingConvention,
+            boolean libraryIsSynchronized) {
+        super();
+        this.runtime = runtime;
+        this.library = library;
+        this.typeMapper = typeMapper;
+        this.functionMapper = functionMapper;
+        this.libraryCallingConvention = libraryCallingConvention;
+        this.libraryIsSynchronized = libraryIsSynchronized;
+    }
 
-        Marshaller[] marshallers = new Marshaller[parameterTypes.length];
-        for (int i = 0; i < marshallers.length; ++i) {
-            marshallers[i] = getMarshaller(parameterTypes[i]);
+    public Invoker createInvoker(Method method) {
+        Collection<Annotation> annotations = sortedAnnotationCollection(method.getAnnotations());
+        String functionName = functionMapper.mapFunctionName(method.getName(), new NativeFunctionMapperContext(library, annotations));
+        long functionAddress = library.getSymbolAddress(functionName);
+        if (functionAddress == 0L) {
+            return new FunctionNotFoundInvoker(method, functionName);
         }
 
-        FunctionInvoker invoker = getFunctionInvoker(resultType);
-        if (resultType.getFromNativeConverter() != null) {
-            invoker = new ConvertingInvoker(resultType.getFromNativeConverter(), resultType.getFromNativeContext(), invoker);
+        FromNativeContext resultContext = new MethodResultContext(NativeRuntime.getInstance(), method);
+        SignatureType signatureType = DefaultSignatureType.create(method.getReturnType(), resultContext);
+        ResultType resultType = getResultType(runtime, method.getReturnType(),
+                resultContext.getAnnotations(), typeMapper.getFromNativeType(signatureType, resultContext),
+                resultContext);
+        
+        FunctionInvoker functionInvoker = getFunctionInvoker(resultType);
+        ParameterType[] parameterTypes = getParameterTypes(runtime, typeMapper, method);
+        //Allow individual methods to set the calling convention to stdcall
+        CallingConvention callingConvention = method.isAnnotationPresent(StdCall.class)
+                ? CallingConvention.STDCALL : libraryCallingConvention;
+        
+        Invoker invoker;
+        if (method.isVarArgs()) {
+            invoker = new VariadicInvoker(runtime, functionInvoker, typeMapper, parameterTypes, functionAddress, resultType, InvokerUtil.requiresErrno(method), callingConvention);
+        } else {
+            Function function = new Function(functionAddress,
+                    getCallContext(resultType, parameterTypes, callingConvention, InvokerUtil.requiresErrno(method)));
+
+            Marshaller[] marshallers = new Marshaller[parameterTypes.length];
+            for (int i = 0; i < marshallers.length; ++i) {
+                marshallers[i] = getMarshaller(parameterTypes[i]);
+            }
+
+            if (resultType.getFromNativeConverter() != null) {
+                functionInvoker = new ConvertingInvoker(resultType.getFromNativeConverter(), resultType.getFromNativeContext(), functionInvoker);
+            }
+
+            return new DefaultInvoker(runtime, library, function, functionInvoker, marshallers);
         }
 
-        return new DefaultInvoker(runtime, nativeLibrary, function, invoker, marshallers);
+        //
+        // If either the method or the library is specified as requiring
+        // synchronization, then wrap the raw invoker in a synchronized proxy
+        //
+        return libraryIsSynchronized || method.isAnnotationPresent(Synchronized.class)
+                ? new SynchronizedInvoker(invoker) : invoker;
     }
 
     private static FunctionInvoker getFunctionInvoker(ResultType resultType) {
@@ -194,6 +281,110 @@ final class DefaultInvokerFactory {
         }
     }
 
+    static class VariadicInvoker implements jnr.ffi.provider.Invoker {
+        private final jnr.ffi.Runtime runtime;
+        private final FunctionInvoker functionInvoker;
+        private final SignatureTypeMapper typeMapper;
+        private final ParameterType[] fixedParameterTypes;
+        private final long functionAddress;
+        private final SigType resultType;
+        private final boolean requiresErrno;
+        private final CallingConvention callingConvention;
+
+        VariadicInvoker(Runtime runtime,
+                FunctionInvoker functionInvoker, SignatureTypeMapper typeMapper,
+                ParameterType[] fixedParameterTypes, long functionAddress,
+                SigType resultType, boolean requiresErrno,
+                CallingConvention callingConvention) {
+            super();
+            this.runtime = runtime;
+            this.functionInvoker = functionInvoker;
+            this.typeMapper = typeMapper;
+            this.fixedParameterTypes = fixedParameterTypes;
+            this.functionAddress = functionAddress;
+            this.resultType = resultType;
+            this.requiresErrno = requiresErrno;
+            this.callingConvention = callingConvention;
+        }
+
+        public final Object invoke(Object self, Object[] parameters) {
+            Object[] varParam = (Object[])parameters[parameters.length - 1];
+            ParameterType[] argTypes = new ParameterType[fixedParameterTypes.length + varParam.length - 1];
+            System.arraycopy(fixedParameterTypes, 0, argTypes, 0, fixedParameterTypes.length - 1);
+
+            Object[] variableArgs = new Object[varParam.length];
+            int variableArgsCount = 0;
+            List<Class<? extends Annotation>> paramAnnotations = new ArrayList<Class<? extends Annotation>>();
+
+            for (Object arg : varParam) {
+                if (arg instanceof Class && Annotation.class.isAssignableFrom((Class)arg)) {
+                    paramAnnotations.add((Class)arg);
+                } else {
+                    Class<?> argClass;
+                    ToNativeConverter<?, ?> toNativeConverter = null;
+                    Collection<Annotation> annos = getAnnotations(paramAnnotations);
+                    paramAnnotations.clear();
+                    ToNativeContext toNativeContext = new SimpleNativeContext(runtime, annos);
+
+                    if (arg != null) {
+                        ToNativeType toNativeType = typeMapper.getToNativeType(DefaultSignatureType.create(arg.getClass(), toNativeContext), toNativeContext);
+                        toNativeConverter = toNativeType == null ? null : toNativeType.getToNativeConverter();
+                        argClass = toNativeConverter == null ? arg.getClass() : toNativeConverter.nativeType();
+                        variableArgs[variableArgsCount] = arg;
+                    } else {
+                        argClass = Pointer.class;
+                        variableArgs[variableArgsCount] = arg;
+                    }
+
+                    argTypes[fixedParameterTypes.length + variableArgsCount - 1] = new ParameterType(
+                            argClass, 
+                            Types.getType(runtime, argClass, annos).getNativeType(), 
+                            annos, 
+                            toNativeConverter, 
+                            new SimpleNativeContext(runtime, annos));
+                    variableArgsCount++;
+                }
+            }
+
+            Function function = new Function(functionAddress,
+                    getCallContext(resultType, argTypes, variableArgsCount + fixedParameterTypes.length - 1, callingConvention, requiresErrno));
+            HeapInvocationBuffer buffer = new HeapInvocationBuffer(function.getCallContext());
+
+            InvocationSession session = new InvocationSession();
+            try {
+                if (parameters != null) for (int i = 0; i < parameters.length - 1; ++i) {
+                    getMarshaller(argTypes[i]).marshal(session, buffer, parameters[i]);
+                }
+                
+                for (int i = 0; i < variableArgsCount; ++i) {
+                    getMarshaller(argTypes[i + fixedParameterTypes.length - 1]).marshal(session, buffer, variableArgs[i]);
+                }
+
+                return functionInvoker.invoke(runtime, function, buffer);
+            } finally {
+                session.finish();
+            }
+        }
+        
+        private static Collection<Annotation> getAnnotations(Collection<Class<? extends Annotation>> klasses) {
+            List<Annotation> ret = new ArrayList<Annotation>();
+            for (Class<? extends Annotation> klass : klasses) {
+                if (klass.getAnnotation(Meta.class) != null) {
+                    for (Annotation anno : klass.getAnnotations()) {
+                        if (anno.annotationType().getName().startsWith("java") 
+                                || Meta.class.equals(anno.annotationType())) {
+                            continue;
+                        }
+                        ret.add(anno);
+                    }
+                } else {
+                    ret.add(AnnotationProxy.newProxy(klass));
+                }
+            }
+            return ret;
+        }
+    }
+
     static class DefaultInvoker implements jnr.ffi.provider.Invoker {
         protected final jnr.ffi.Runtime runtime;
         final Function function;
@@ -223,7 +414,36 @@ final class DefaultInvokerFactory {
             }
         }
     }
-    
+
+    private static final class SynchronizedInvoker implements Invoker {
+        private final Invoker invoker;
+        public SynchronizedInvoker(Invoker invoker) {
+            this.invoker = invoker;
+        }
+
+        @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+        public Object invoke(Object self, Object[] parameters) {
+            synchronized (self) {
+                return invoker.invoke(self, parameters);
+            }
+        }
+    }
+
+    private static final class FunctionNotFoundInvoker implements Invoker {
+        private final Method method;
+        private final String functionName;
+
+        private FunctionNotFoundInvoker(Method method, String functionName) {
+            this.method = method;
+            this.functionName = functionName;
+        }
+
+        @Override
+        public Object invoke(Object self, Object[] parameters) {
+            throw new UnsatisfiedLinkError(String.format("native method '%s' not found for method %s", functionName,  method));
+        }
+    }
+
     static interface Marshaller {
         public abstract void marshal(InvocationSession session, HeapInvocationBuffer buffer, Object parameter);
     }

--- a/src/main/java/jnr/ffi/provider/jffi/InvokerUtil.java
+++ b/src/main/java/jnr/ffi/provider/jffi/InvokerUtil.java
@@ -196,7 +196,11 @@ final class InvokerUtil {
     }
 
     static CallContext getCallContext(SigType resultType, SigType[] parameterTypes, jnr.ffi.CallingConvention convention, boolean requiresErrno) {
-        com.kenai.jffi.Type[] nativeParamTypes = new com.kenai.jffi.Type[parameterTypes.length];
+        return getCallContext(resultType, parameterTypes, parameterTypes.length, convention, requiresErrno);
+    }
+
+    static CallContext getCallContext(SigType resultType, SigType[] parameterTypes, int paramTypesLength, jnr.ffi.CallingConvention convention, boolean requiresErrno) {
+        com.kenai.jffi.Type[] nativeParamTypes = new com.kenai.jffi.Type[paramTypesLength];
 
         for (int i = 0; i < nativeParamTypes.length; ++i) {
             nativeParamTypes[i] = jffiType(parameterTypes[i].getNativeType());

--- a/src/main/java/jnr/ffi/provider/jffi/ReflectionLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/ReflectionLibraryLoader.java
@@ -18,15 +18,8 @@
 
 package jnr.ffi.provider.jffi;
 
-import com.kenai.jffi.Function;
-import jnr.ffi.CallingConvention;
-import jnr.ffi.LibraryOption;
-import jnr.ffi.Runtime;
-import jnr.ffi.Variable;
-import jnr.ffi.annotations.StdCall;
-import jnr.ffi.annotations.Synchronized;
-import jnr.ffi.mapper.*;
-import jnr.ffi.provider.*;
+import static jnr.ffi.provider.jffi.InvokerUtil.getCallingConvention;
+import static jnr.ffi.util.Annotations.sortedAnnotationCollection;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -36,8 +29,21 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import static jnr.ffi.provider.jffi.InvokerUtil.*;
-import static jnr.ffi.util.Annotations.sortedAnnotationCollection;
+import jnr.ffi.LibraryOption;
+import jnr.ffi.Runtime;
+import jnr.ffi.Variable;
+import jnr.ffi.annotations.Synchronized;
+import jnr.ffi.mapper.CachingTypeMapper;
+import jnr.ffi.mapper.CompositeTypeMapper;
+import jnr.ffi.mapper.FunctionMapper;
+import jnr.ffi.mapper.SignatureTypeMapper;
+import jnr.ffi.mapper.SignatureTypeMapperAdapter;
+import jnr.ffi.mapper.TypeMapper;
+import jnr.ffi.provider.IdentityFunctionMapper;
+import jnr.ffi.provider.Invoker;
+import jnr.ffi.provider.LoadedLibrary;
+import jnr.ffi.provider.NativeInvocationHandler;
+import jnr.ffi.provider.NullTypeMapper;
 
 /**
  *
@@ -48,20 +54,6 @@ class ReflectionLibraryLoader extends LibraryLoader {
     <T> T loadLibrary(NativeLibrary library, Class<T> interfaceClass, Map<LibraryOption, ?> libraryOptions) {
         return interfaceClass.cast(Proxy.newProxyInstance(interfaceClass.getClassLoader(),
                 new Class[]{ interfaceClass, LoadedLibrary.class }, new NativeInvocationHandler(new LazyLoader<T>(library, interfaceClass, libraryOptions))));
-    }
-
-    private static final class SynchronizedInvoker implements Invoker {
-        private final Invoker invoker;
-        public SynchronizedInvoker(Invoker invoker) {
-            this.invoker = invoker;
-        }
-
-        @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-        public Object invoke(Object self, Object[] parameters) {
-            synchronized (self) {
-                return invoker.invoke(self, parameters);
-            }
-        }
     }
 
     private static final class FunctionNotFoundInvoker implements Invoker {
@@ -93,7 +85,7 @@ class ReflectionLibraryLoader extends LibraryLoader {
     }
 
     private static final class LazyLoader<T> extends AbstractMap<Method, Invoker> {
-        private final DefaultInvokerFactory invokerFactory = new DefaultInvokerFactory();
+        private final DefaultInvokerFactory invokerFactory;
         private final jnr.ffi.Runtime runtime = NativeRuntime.getInstance();
         private final AsmClassLoader classLoader = new AsmClassLoader();
         private final SignatureTypeMapper typeMapper;
@@ -102,7 +94,6 @@ class ReflectionLibraryLoader extends LibraryLoader {
 
         private final boolean libraryIsSynchronized;
 
-        @SuppressWarnings("unused")
         private final NativeLibrary library;
         @SuppressWarnings("unused")
         private final Class<T> interfaceClass;
@@ -135,6 +126,7 @@ class ReflectionLibraryLoader extends LibraryLoader {
                     new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, typeMapper, classLoader), classLoader, NativeLibraryLoader.ASM_ENABLED)));
             libraryCallingConvention = getCallingConvention(interfaceClass, libraryOptions);
             libraryIsSynchronized = interfaceClass.isAnnotationPresent(Synchronized.class);
+            invokerFactory = new DefaultInvokerFactory(runtime, library, this.typeMapper, functionMapper, libraryCallingConvention, libraryIsSynchronized);
         }
 
         @Override
@@ -156,41 +148,8 @@ class ReflectionLibraryLoader extends LibraryLoader {
             } else if (method.getName().equals("getRuntime") && method.getReturnType().isAssignableFrom(NativeRuntime.class)) {
                 return new GetRuntimeInvoker(runtime);
             } else {
-                return getFunctionInvoker(method);
+                return invokerFactory.createInvoker(method);
             }
-        }
-
-        private Invoker getFunctionInvoker(Method method) {
-            Collection<Annotation> annotations = sortedAnnotationCollection(method.getAnnotations());
-            String functionName = functionMapper.mapFunctionName(method.getName(), new NativeFunctionMapperContext(library, annotations));
-            long functionAddress = library.getSymbolAddress(functionName);
-            if (functionAddress == 0L) {
-                return new FunctionNotFoundInvoker(method, functionName);
-            }
-
-            FromNativeContext resultContext = new MethodResultContext(NativeRuntime.getInstance(), method);
-            SignatureType signatureType = DefaultSignatureType.create(method.getReturnType(), resultContext);
-            ResultType resultType = getResultType(runtime, method.getReturnType(),
-                    resultContext.getAnnotations(), typeMapper.getFromNativeType(signatureType, resultContext),
-                    resultContext);
-
-            ParameterType[] parameterTypes = getParameterTypes(runtime, typeMapper, method);
-
-            // Allow individual methods to set the calling convention to stdcall
-            CallingConvention callingConvention = method.isAnnotationPresent(StdCall.class)
-                    ? CallingConvention.STDCALL : libraryCallingConvention;
-
-            Function function = new Function(functionAddress,
-                    getCallContext(resultType, parameterTypes, callingConvention, InvokerUtil.requiresErrno(method)));
-
-            Invoker invoker = invokerFactory.createInvoker(runtime, library, function, resultType, parameterTypes);
-
-            //
-            // If either the method or the library is specified as requiring
-            // synchronization, then wrap the raw invoker in a synchronized proxy
-            //
-            return libraryIsSynchronized || method.isAnnotationPresent(Synchronized.class)
-                    ? new SynchronizedInvoker(invoker) : invoker;
         }
 
         private Invoker getVariableAccessor(Method method) {

--- a/src/main/java/jnr/ffi/util/AnnotationProperty.java
+++ b/src/main/java/jnr/ffi/util/AnnotationProperty.java
@@ -1,0 +1,287 @@
+package jnr.ffi.util;
+
+/*
+ *    Copyright 2010 The Miyamoto Team
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import java.util.Arrays;
+
+/**
+ * Describes an annotation property.
+ *
+ * @version $Id$
+ */
+final class AnnotationProperty {
+
+    /**
+     * The property name.
+     */
+    private final String name;
+
+    /**
+     * The property type.
+     */
+    private final Class<?> type;
+
+    /**
+     * The property value. This field can be mutable.
+     */
+    private Object value;
+
+    /**
+     * Creates a new annotation property instance.
+     *
+     * @param name the property name.
+     * @param type the property type.
+     */
+    public AnnotationProperty(String name, Class<?> type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    /**
+     * Returns the property name.
+     *
+     * @return the property name.
+     */
+    public String getName() {
+        return this.name;
+    }
+
+    /**
+     * Returns the property type.
+     *
+     * @return the property type.
+     */
+    public Class<?> getType() {
+        return this.type;
+    }
+
+    /**
+     * Returns the property value.
+     *
+     * @return the property value.
+     */
+    public Object getValue() {
+        return this.value;
+    }
+
+    /**
+     * Sets the property value.
+     *
+     * @param value the property value.
+     */
+    public void setValue(Object value) {
+        if (value != null && !(this.type.isAssignableFrom(value.getClass())
+                || (this.type == Boolean.TYPE && value.getClass() == Boolean.class)
+                || (this.type == Byte.TYPE && value.getClass() == Byte.class)
+                || (this.type == Character.TYPE && value.getClass() == Character.class)
+                || (this.type == Double.TYPE && value.getClass() == Double.class)
+                || (this.type == Float.TYPE && value.getClass() == Float.class)
+                || (this.type == Integer.TYPE && value.getClass() == Integer.class)
+                || (this.type == Long.TYPE && value.getClass() == Long.class)
+                || (this.type == Short.TYPE && value.getClass() == Short.class))) {
+            throw new IllegalArgumentException("Cannot assign value of type '"
+                    + value.getClass().getName()
+                    + "' to property '"
+                    + this.name
+                    + "' of type '"
+                    + this.type.getName()
+                    + "'");
+        }
+        this.value = value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + this.name.hashCode();
+        result = prime * result + this.type.hashCode();
+        result = prime * result + this.getValueHashCode();
+        return result;
+    }
+
+    /**
+     * Calculates this annotation value hash code.
+     *
+     * @return this annotation value hash code.
+     */
+    protected int getValueHashCode() {
+        if (this.value == null) {
+            return 0;
+        }
+
+        if (!this.type.isArray()) {
+            return this.value.hashCode();
+        }
+
+        if (this.type == byte[].class) {
+            return Arrays.hashCode((byte[]) this.value);
+        }
+        if (this.type == char[].class) {
+            return Arrays.hashCode((char[]) this.value);
+        }
+        if (this.type == double[].class) {
+            return Arrays.hashCode((double[]) this.value);
+        }
+        if (this.type == float[].class) {
+            return Arrays.hashCode((float[]) this.value);
+        }
+        if (this.type == int[].class) {
+            return Arrays.hashCode((int[]) this.value);
+        }
+        if (this.type == long[].class) {
+            return Arrays.hashCode((long[]) this.value);
+        }
+        if (this.type == short[].class) {
+            return Arrays.hashCode((short[]) this.value);
+        }
+        if (this.type == boolean[].class) {
+            return Arrays.hashCode((boolean[]) this.value);
+        }
+        return Arrays.hashCode((Object[]) this.value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (this.getClass() != obj.getClass()) {
+            return false;
+        }
+
+        AnnotationProperty other = (AnnotationProperty) obj;
+
+        if (this.name == null) {
+            if (other.getName() != null) {
+                return false;
+            }
+        } else if (!this.name.equals(other.getName())) {
+            return false;
+        }
+
+        if (this.type == null) {
+            if (other.getType() != null) {
+                return false;
+            }
+        } else if (!this.type.equals(other.getType())) {
+            return false;
+        }
+
+        if (this.value == null) {
+            if (other.getValue() != null) {
+                return false;
+            }
+        } else {
+            // Check for primitive, string, class, enum const, annotation
+            if (!this.type.isArray()) {
+                return this.value.equals(other.getValue());
+            }
+
+            // Check for array of string, class, enum const, annotation
+            if (this.value instanceof Object[] && other.getValue() instanceof Object[]) {
+                Arrays.equals((Object[]) this.value, (Object[]) other.getValue());
+            }
+
+            // Deal with array of primitives
+            if (this.type == byte[].class) {
+                return Arrays.equals((byte[]) this.value, (byte[]) other.getValue());
+            }
+            if (this.type == char[].class) {
+                return Arrays.equals((char[]) this.value, (char[]) other.getValue());
+            }
+            if (this.type == double[].class) {
+                return Arrays.equals((double[]) this.value, (double[]) other.getValue());
+            }
+            if (this.type == float[].class) {
+                return Arrays.equals((float[]) this.value, (float[]) other.getValue());
+            }
+            if (this.type == int[].class) {
+                return Arrays.equals((int[]) this.value, (int[]) other.getValue());
+            }
+            if (this.type == long[].class) {
+                return Arrays.equals((long[]) this.value, (long[]) other.getValue());
+            }
+            if (this.type == short[].class) {
+                return Arrays.equals((short[]) this.value, (short[]) other.getValue());
+            }
+            if (this.type == boolean[].class) {
+                return Arrays.equals((boolean[]) this.value, (boolean[]) other.getValue());
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return "(name="
+                + this.name
+                + ", type="
+                + (this.type.isArray() ? (this.type.getComponentType().getName() + "[]") : this.type.getName())
+                + ", value="
+                + this.valueToString()
+                + ")";
+    }
+
+    /**
+     * Calculates the {@code toString} of the property value.
+     *
+     * @return the {@code toString} of the property value.
+     */
+    protected String valueToString() {
+        if (!this.type.isArray()) {
+            return String.valueOf(this.value);
+        }
+
+        Class<?> arrayType = this.type.getComponentType();
+        if (arrayType == Boolean.TYPE) {
+            return Arrays.toString((boolean[]) this.value);
+        } else if (arrayType == Byte.TYPE) {
+            return Arrays.toString((byte[]) this.value);
+        } else if (arrayType == Character.TYPE) {
+            return Arrays.toString((char[]) this.value);
+        } else if (arrayType == Double.TYPE) {
+            return Arrays.toString((double[]) this.value);
+        } else if (arrayType == Float.TYPE) {
+            return Arrays.toString((float[]) this.value);
+        } else if (arrayType == Integer.TYPE) {
+            return Arrays.toString((int[]) this.value);
+        } else if (arrayType == Long.TYPE) {
+            return Arrays.toString((long[]) this.value);
+        } else if (arrayType == Short.TYPE) {
+            return Arrays.toString((short[]) this.value);
+        }
+
+        return Arrays.toString((Object[]) this.value);
+    }
+
+}

--- a/src/main/java/jnr/ffi/util/AnnotationProxy.java
+++ b/src/main/java/jnr/ffi/util/AnnotationProxy.java
@@ -1,0 +1,285 @@
+package jnr.ffi.util;
+
+/*
+ *    Copyright 2010 The Miyamoto Team
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+/**
+ * 
+ *
+ * @param <A> The annotation type has to be proxed.
+ * @version $Id$
+ */
+public final class AnnotationProxy<A extends Annotation> implements Annotation, InvocationHandler {
+
+    /**
+     * The multiplicator required in the hash code calculation.
+     */
+    private static final int MEMBER_NAME_MULTIPLICATOR = 127;
+
+    /**
+     * Creates a new annotation proxy.
+     *
+     * @param <A> the annotation type has to be proxed.
+     * @param annotationType the annotation type class has to be proxed.
+     * @return a new annotation proxy.
+     */
+    public static <A extends Annotation> AnnotationProxy<A> newProxy(Class<A> annotationType) {
+        if (annotationType == null) {
+            throw new IllegalArgumentException("Parameter 'annotationType' must be not null");
+        }
+        return new AnnotationProxy<A>(annotationType);
+    }
+
+    /**
+     * Retrieves the annotation proxy, if any, given the annotation.
+     *
+     * @param obj the annotation.
+     * @return the annotation proxy, if any, given the annotation.
+     */
+    private static AnnotationProxy<?> getAnnotationProxy(Object obj) {
+        if (Proxy.isProxyClass(obj.getClass())) {
+            InvocationHandler handler = Proxy.getInvocationHandler(obj);
+            if (handler instanceof AnnotationProxy) {
+                return (AnnotationProxy<?>) handler;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Access to the declared methods of an annotation, given the type.
+     *
+     * @param <A> the annotation type.
+     * @param annotationType the annotation type class.
+     * @return the declared methods of an annotation, given the type.
+     */
+    private static <A extends Annotation> Method[] getDeclaredMethods(final Class<A> annotationType) {
+        return AccessController.doPrivileged(
+                new PrivilegedAction<Method[]>() {
+                    public Method[] run() {
+                        final Method[] declaredMethods = annotationType.getDeclaredMethods();
+                        AccessibleObject.setAccessible(declaredMethods, true);
+                        return declaredMethods;
+                    }
+                });
+    }
+
+    /**
+     * The annotation type class has to be proxed.
+     */
+    private final Class<A> annotationType;
+
+    /**
+     * The annotation properties registry.
+     */
+    private final Map<String, AnnotationProperty> properties = new LinkedHashMap<String, AnnotationProperty>();
+
+    /**
+     * The proxed annotation.
+     */
+    private final A proxedAnnotation;
+
+    /**
+     * Build a new proxy annotation given the annotation type.
+     *
+     * @param annotationType the annotation type class has to be proxed.
+     */
+    private AnnotationProxy(Class<A> annotationType) {
+        this.annotationType = annotationType;
+
+        String propertyName;
+        Class<?> returnType;
+        Object defaultValue;
+        for (Method method : getDeclaredMethods(annotationType)) {
+            propertyName = method.getName();
+            returnType = method.getReturnType();
+            defaultValue = method.getDefaultValue();
+
+            AnnotationProperty property = new AnnotationProperty(propertyName, returnType);
+            property.setValue(defaultValue);
+            this.properties.put(propertyName, property);
+        }
+
+        this.proxedAnnotation = annotationType.cast(Proxy.newProxyInstance(annotationType.getClassLoader(),
+                new Class<?>[]{ annotationType },
+                this));
+    }
+
+    /**
+     * Set a property value.
+     *
+     * @param name the property name.
+     * @param value the property value.
+     */
+    public void setProperty(String name, Object value) {
+        if (name == null) {
+            throw new IllegalArgumentException("Parameter 'name' must be not null");
+        }
+        if (value == null) {
+            throw new IllegalArgumentException("Parameter 'value' must be not null");
+        }
+
+        if (!this.properties.containsKey(name)) {
+            throw new IllegalArgumentException("Annotation '"
+                    + this.annotationType.getName()
+                    + "' does not contain a property named '"
+                    + name
+                    + "'");
+        }
+
+        this.properties.get(name).setValue(value);
+    }
+
+    /**
+     * Returns the property value, given the name, if present.
+     *
+     * @param name the property name.
+     * @return the property value, given the name, if present.
+     */
+    public Object getProperty(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("Parameter 'name' must be not null");
+        }
+        return this.properties.get(name).getValue();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        String name = method.getName();
+        if (this.properties.containsKey(name)) {
+            return this.properties.get(name).getValue();
+        }
+        return method.invoke(this, args);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Class<? extends Annotation> annotationType() {
+        return this.annotationType;
+    }
+
+    /**
+     * Returns the proxed annotation.
+     *
+     * @return the proxed annotation.
+     */
+    public A getProxedAnnotation() {
+        return this.proxedAnnotation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (obj == null) {
+            return false;
+        }
+
+        if (!this.annotationType.isInstance(obj)) {
+            return false;
+        }
+
+        String propertyName;
+        AnnotationProperty expected;
+        for (Method method : getDeclaredMethods(this.annotationType())) {
+            propertyName = method.getName();
+
+            if (!this.properties.containsKey(propertyName)) {
+                return false;
+            }
+
+            expected = this.properties.get(propertyName);
+            AnnotationProperty actual = new AnnotationProperty(propertyName, method.getReturnType());
+
+            AnnotationProxy<?> proxy = getAnnotationProxy(obj);
+            if (proxy != null) {
+                actual.setValue(proxy.getProperty(propertyName));
+            } else {
+                try {
+                    actual.setValue(method.invoke(obj));
+                } catch (IllegalArgumentException e) {
+                    return false;
+                } catch (IllegalAccessException e) {
+                    throw new AssertionError(e);
+                } catch (InvocationTargetException e) {
+                    return false;
+                }
+            }
+
+            if (!expected.equals(actual)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int hashCode = 0;
+
+        for (Entry<String, AnnotationProperty> property : this.properties.entrySet()) {
+            hashCode += (MEMBER_NAME_MULTIPLICATOR * property.getKey().hashCode() ^ property.getValue().getValueHashCode());
+        }
+
+        return hashCode;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder("@")
+                                        .append(this.annotationType.getName())
+                                        .append('(');
+        int counter = 0;
+        for (Entry<String, AnnotationProperty> property : this.properties.entrySet()) {
+            if (counter > 0) {
+                stringBuilder.append(", ");
+            }
+            stringBuilder.append(property.getKey())
+                         .append('=')
+                         .append(property.getValue().valueToString());
+            counter++;
+        }
+        return stringBuilder.append(')').toString();
+    }
+
+}

--- a/src/test/java/jnr/ffi/VarargsTest.java
+++ b/src/test/java/jnr/ffi/VarargsTest.java
@@ -1,7 +1,7 @@
 package jnr.ffi;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 import jnr.ffi.annotations.Encoding;
 import jnr.ffi.annotations.Meta;
@@ -39,21 +39,21 @@ public class VarargsTest {
         Assert.assertEquals("12345", result);
     }
 
-    @Test public void testMetaAscii() {
+    @Test public void testMetaAscii() throws UnsupportedEncodingException {
         Pointer ptr = Runtime.getRuntime(c).getMemoryManager().allocate(5000);
         int size = c.snprintf(ptr, 5000, "%s", AsciiEncoding.class, "\u7684");
         Assert.assertEquals(1, size);
-        String result = ptr.getString(0, size, StandardCharsets.US_ASCII);
-        String expected = new String("\u7684".getBytes(StandardCharsets.US_ASCII), StandardCharsets.US_ASCII);
+        String result = ptr.getString(0, size, Charset.forName("ASCII"));
+        String expected = new String("\u7684".getBytes("ASCII"), "ASCII");
         Assert.assertEquals(expected, result);
     }
 
-    @Test public void testMetaUtf8() {
+    @Test public void testMetaUtf8() throws UnsupportedEncodingException {
         Pointer ptr = Runtime.getRuntime(c).getMemoryManager().allocate(5000);
         int size = c.snprintf(ptr, 5000, "%s", UTF8Encoding.class, "\u7684");
         Assert.assertEquals(3, size);
-        String result = ptr.getString(0, size, StandardCharsets.UTF_8);
-        String expected = new String("\u7684".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+        String result = ptr.getString(0, size, Charset.forName("UTF-8"));
+        String expected = new String("\u7684".getBytes("UTF-8"), "UTF-8");
         Assert.assertEquals(expected, result);
     }
 

--- a/src/test/java/jnr/ffi/VarargsTest.java
+++ b/src/test/java/jnr/ffi/VarargsTest.java
@@ -1,0 +1,69 @@
+package jnr.ffi;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import jnr.ffi.annotations.Encoding;
+import jnr.ffi.annotations.Meta;
+import jnr.ffi.provider.FFIProvider;
+import jnr.ffi.types.size_t;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class VarargsTest {
+    public static interface C {
+        public int snprintf(Pointer buffer, @size_t long bufferSize, String format, Object... varargs);
+    }
+
+    static C c;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        LibraryLoader<C> loader = FFIProvider.getSystemProvider().createLibraryLoader(C.class);
+        c = loader.load("c");
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        c = null;
+    }
+
+    @Test public void testSizeT() {
+        Pointer ptr = Runtime.getRuntime(c).getMemoryManager().allocate(5000);
+        int size = c.snprintf(ptr, 5000, "%zu", size_t.class, 12345);
+        Assert.assertEquals(5, size);
+        String result = ptr.getString(0, size, Charset.defaultCharset());
+        Assert.assertEquals("12345", result);
+    }
+
+    @Test public void testMetaAscii() {
+        Pointer ptr = Runtime.getRuntime(c).getMemoryManager().allocate(5000);
+        int size = c.snprintf(ptr, 5000, "%s", AsciiEncoding.class, "\u7684");
+        Assert.assertEquals(1, size);
+        String result = ptr.getString(0, size, StandardCharsets.US_ASCII);
+        String expected = new String("\u7684".getBytes(StandardCharsets.US_ASCII), StandardCharsets.US_ASCII);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Test public void testMetaUtf8() {
+        Pointer ptr = Runtime.getRuntime(c).getMemoryManager().allocate(5000);
+        int size = c.snprintf(ptr, 5000, "%s", UTF8Encoding.class, "\u7684");
+        Assert.assertEquals(3, size);
+        String result = ptr.getString(0, size, StandardCharsets.UTF_8);
+        String expected = new String("\u7684".getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8);
+        Assert.assertEquals(expected, result);
+    }
+
+    @Meta
+    @Encoding(value="ASCII")
+    public static @interface AsciiEncoding {
+    }
+
+    @Meta
+    @Encoding(value="UTF-8")
+    public static @interface UTF8Encoding {
+    }
+}


### PR DESCRIPTION
Adds support for invoking native variadic methods.  

This is implemented using the reflection based code path (with a fallback to the reflection based code path from the asm code path for variadic methods only).  This code supports one subtlety:  annotations to  parameters can be supplied by including the class of the annotation type immediately preceding the argument.

For example, given the signature

     public int foo(Object... foo)

you could pass a size_t like this

     foo(size_t.class, 1)

To supply annotations (like Encoding) that take arguments you can create another annotation type, annotate it with Meta, and apply that annotation.  For example:

    @Meta
    @Encoding(value="UTF-8")
    public static @interface UTF8Encoding {
    }

    foo(UTF8Encoding.class, "foo")

would be treated as having annotated the first argument with the @Encoding("UTF-8") annotation

