### PR TITLE
Fix type mapping for closures

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
@@ -91,8 +91,12 @@ public class AsmLibraryLoader extends LibraryLoader {
             typeMapper = new NullTypeMapper();
         }
 
+        CompositeTypeMapper closureTypeMapper = new CompositeTypeMapper(typeMapper, 
+                new CachingTypeMapper(new InvokerTypeMapper(null, classLoader, NativeLibraryLoader.ASM_ENABLED)),
+                new CachingTypeMapper(new AnnotationTypeMapper()));
+        
         typeMapper = new CompositeTypeMapper(typeMapper, 
-                new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, typeMapper, classLoader), classLoader, NativeLibraryLoader.ASM_ENABLED)),
+                new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, closureTypeMapper, classLoader), classLoader, NativeLibraryLoader.ASM_ENABLED)),
                 new CachingTypeMapper(new AnnotationTypeMapper()));
         
         CallingConvention libraryCallingConvention = getCallingConvention(interfaceClass, libraryOptions);

--- a/src/main/java/jnr/ffi/provider/jffi/ClosureUtil.java
+++ b/src/main/java/jnr/ffi/provider/jffi/ClosureUtil.java
@@ -24,6 +24,7 @@ import jnr.ffi.mapper.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.Collection;
 
 import static jnr.ffi.util.Annotations.sortedAnnotationCollection;
@@ -50,7 +51,7 @@ final class ClosureUtil {
         Collection<Annotation> annotations = sortedAnnotationCollection(m.getParameterAnnotations()[idx]);
         Class declaredJavaClass = m.getParameterTypes()[idx];
         FromNativeContext context = new SimpleNativeContext(runtime, annotations);
-        SignatureType signatureType = DefaultSignatureType.create(declaredJavaClass, context);
+        SignatureType signatureType = new DefaultSignatureType(declaredJavaClass, context.getAnnotations(), m.getGenericParameterTypes()[idx]);
         jnr.ffi.mapper.FromNativeType fromNativeType = typeMapper.getFromNativeType(signatureType, context);
         FromNativeConverter converter = fromNativeType != null ? fromNativeType.getFromNativeConverter() : null;
         Class javaClass = converter != null ? converter.nativeType() : declaredJavaClass;


### PR DESCRIPTION
A closure that includes an EnumSet in the signature will cause the library that contains it to fail.  For example:

     public static interface FooCallback {
       @Delegate void apply(EnumSet<Flags> flags);
     }

    public void foo(FooCallback cb);

Caused by two things:
1.)  The NativeClosureManager is constructed without the InvokerTypeMapper that has the converters for EnumSets
2.)  The SignatureType that is constructed for a closure parameter loses the generic type information since the FromNativeContext is not a MethodResultContext