### PR TITLE
exclude the wrong paths for the wrong cpu architecture

### DIFF
--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -439,8 +439,19 @@ public abstract class Platform {
                 }
             };
 
+            Pattern exclude;
+            if (getCPU() == CPU.X86_64) {
+                exclude = Pattern.compile(".*(lib32|i[0-9]86).*");
+            }
+            else {
+                exclude = Pattern.compile(".*(lib64|amd64|x86_64).*");
+            }
+
             List<File> matches = new LinkedList<File>();
             for (String path : libraryPath) {
+                if (exclude.matcher(path).matches()) {
+                    continue;
+                }
                 File[] files = new File(path).listFiles(filter);
                 if (files != null && files.length > 0) {
                     matches.addAll(Arrays.asList(files));


### PR DESCRIPTION
using ld.so.conf on multiarch linux systems will include search
paths for both 32 and 64 architecture. when finding the native
library we need to look only at the paths which contains the
libraries for the cpu in use.

fixes https://github.com/jruby/jruby/issues/3409

Sponsored by Lookout Inc.