### PR TITLE
improve the check on 32bit vs 64bit directory name

### DIFF
--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -440,11 +440,13 @@ public abstract class Platform {
             };
 
             Pattern exclude;
+            // there are /libx32 directories in wild on ubuntu 14.04 and the
+            // oracle-java8-installer package
             if (getCPU() == CPU.X86_64) {
-                exclude = Pattern.compile(".*(lib32|i[0-9]86).*");
+                exclude = Pattern.compile(".*(lib[a-z]*32|i[0-9]86).*");
             }
             else {
-                exclude = Pattern.compile(".*(lib64|amd64|x86_64).*");
+                exclude = Pattern.compile(".*(lib[a-z]*64|amd64|x86_64).*");
             }
 
             List<File> matches = new LinkedList<File>();


### PR DESCRIPTION
there are indeed /libx32/ on ubuntu 14.04 using the oracle-java8-installer
package. this patch is to make the detection of those directories more lenient.

fixes https://github.com/jruby/jruby/issues/3409

Sponsored by Lookout Inc.