### PR TITLE
Ignore default methods when scanning interfaces

### DIFF
--- a/src/main/java/jnr/ffi/provider/InterfaceScanner.java
+++ b/src/main/java/jnr/ffi/provider/InterfaceScanner.java
@@ -69,6 +69,36 @@ public class InterfaceScanner {
         };
     }
     
+    private static final Method methodIsDefault;
+
+    static {
+        Method isDefault = null;
+
+        try {
+            isDefault = Method.class.getMethod("isDefault", null);
+        } catch (NoSuchMethodException e) {
+            // expected for jre < 1.8
+        }
+
+        methodIsDefault = isDefault;
+    }
+
+    private static boolean isDefault(Method method) {
+        if (methodIsDefault == null) {
+            return false;
+        }
+
+        try {
+            return Boolean.TRUE.equals(methodIsDefault.invoke(method));
+        } catch (ReflectiveOperationException e) {
+            // e can throw one of:
+            // * IllegalAccessException, but we know isDefault is public.
+            // * InvocationTargetException, but we know isDefault doesn't throw.
+            // but java doesn't let us prove this invariants, so we do this.
+            throw new RuntimeException("Unexpected error attempting to call isDefault method", e);
+        }
+    }
+
     private final class FunctionsIterator implements Iterator<NativeFunction> {
         private final java.lang.reflect.Method[] methods;
         private int nextIndex;
@@ -81,7 +111,8 @@ public class InterfaceScanner {
         @Override
         public boolean hasNext() {
             for (; nextIndex < methods.length; nextIndex++) {
-                if (!Variable.class.isAssignableFrom(methods[nextIndex].getReturnType())) {
+                if (!Variable.class.isAssignableFrom(methods[nextIndex].getReturnType())
+                        && !isDefault(methods[nextIndex])) {
                     return true;
                 }
             }

--- a/src/main/java/jnr/ffi/provider/InterfaceScanner.java
+++ b/src/main/java/jnr/ffi/provider/InterfaceScanner.java
@@ -90,11 +90,14 @@ public class InterfaceScanner {
 
         try {
             return Boolean.TRUE.equals(methodIsDefault.invoke(method));
-        } catch (ReflectiveOperationException e) {
+        } catch (Exception e) {
             // e can throw one of:
             // * IllegalAccessException, but we know isDefault is public.
             // * InvocationTargetException, but we know isDefault doesn't throw.
             // but java doesn't let us prove this invariants, so we do this.
+            // And we can't catch ReflectiveOperationException as it was
+            // introduced in Java SE 1.7, so we have to catch the next common
+            // superclass (Exception).
             throw new RuntimeException("Unexpected error attempting to call isDefault method", e);
         }
     }


### PR DESCRIPTION
Namely so that default methods can be used to emulate macros defined in
header files we're often replacing when doing ffi work.

We must use reflection to call Method.isDefault as it's only available
as of Java SE 8 (as are default methods).

Implementing a library's API's macros next to the rest of the ffi declarations seems like a sensible thing to do. Currently, a default method's implementation will be ignored and a link error will result on trying to call the method (if it is indeed only a macro and not an exported symbol). Issues could arise if someone is relying on this behavior, although that would strike me as odd. This could be mitigated with a `@Ignore` annotation on default methods (which would similarly cause the interface scanner to ignore the method), which I'm happy to implement if there's concern.