### PR TITLE
Map null callback objects to null pointers

### DIFF
--- a/libtest/ClosureTest.c
+++ b/libtest/ClosureTest.c
@@ -15,7 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+int testClosureNull(int (*closure)(void), int defaultValue)
+{
+    return closure ? (*closure)() : defaultValue;
+}
 void testClosureVrV(void (*closure)(void))
 {
     (*closure)();

--- a/src/main/java/jnr/ffi/provider/jffi/NativeClosureManager.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeClosureManager.java
@@ -91,6 +91,10 @@ final class NativeClosureManager implements ClosureManager {
         }
 
         public Pointer toNative(T value, ToNativeContext context) {
+            if (value == null) {
+                return null;
+            }
+            
             // If passing down a function pointer, don't re-wrap it
             if (value instanceof ClosureFromNativeConverter.AbstractClosurePointer) {
                 return (ClosureFromNativeConverter.AbstractClosurePointer) value;

--- a/src/test/java/jnr/ffi/DelegateTest.java
+++ b/src/test/java/jnr/ffi/DelegateTest.java
@@ -51,6 +51,10 @@ public class DelegateTest {
     }
     
     public static interface TestLib {
+        public static interface CallableNull {
+            @Delegate public int call();
+        }
+        int testClosureNull(CallableNull closure, int defaultValue);
         public static interface CallableVrV {
             @Delegate public void call();
         }
@@ -149,6 +153,26 @@ public class DelegateTest {
         Pointer ret_pointer(ReusableCallable callable);
         public CallableVrV ret_pointer(CallableVrV callable);
         public CallableIrV ret_pointer(CallableIrV callable);
+    }
+    @Test
+    public void closureNullWithValue() {
+        final boolean[] called = { false };
+        final TestLib.CallableNull closure = new TestLib.CallableNull() {
+
+            public int call() {
+                called[0] = true;
+                return 42;
+            }
+        };
+        int retValue = lib.testClosureNull(closure, 41);
+        assertTrue("Callable not called", called[0]);
+        assertEquals("Incorrect return value from callable", 42, retValue);
+    }
+    @Test
+    public void closureNullWithNull() {
+        final TestLib.CallableNull closure = null;
+        int retValue = lib.testClosureNull(closure, 41);
+        assertEquals("Incorrect return value from callable", 41, retValue);
     }
     @Test
     public void closureVrV() {


### PR DESCRIPTION
When passing null as value for a callback parameter to a native function a native closure gets created which wraps a null callable. A non-null pointer then gets passed to the native code. When the java closure gets invoke this triggers a null pointer exception at https://github.com/jnr/jnr-ffi/blob/master/src/main/java/jnr/ffi/provider/jffi/NativeClosureProxy.java#L57
Additionally this can end up changing the semantics of the function call since a non-null parameter is passed where null was intended. This is what's happening in #61.
This PR adds a null check in the 'to native' conversion of delegate types that returns a null Pointer instance.