### PR TITLE
Improvements and fixes for errno saving to fix #78.

### DIFF
--- a/src/main/java/jnr/ffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/LibraryLoader.java
@@ -78,6 +78,41 @@ public abstract class LibraryLoader<T> {
     }
 
     /**
+     * When either the {@link jnr.ffi.annotations.SaveError} or
+     * {@link jnr.ffi.annotations.IgnoreError} annotations are used, the
+     * following matrix applies:
+     *
+     * (SL = save at library level, IM = ignore at method level, etc)
+     *
+     * <pre>
+     *         | none |  SL  |  IL  | SL+IL|
+     * -------------------------------------
+     * none    | save | save | ignr | save |
+     * SM      | save | save | save | save |
+     * IM      | ignr | ignr | ignr | ignr |
+     * SM + IM | save | save | save | save |
+     * </pre>
+     */
+    public static boolean saveError(Map<LibraryOption, ?> options, boolean methodHasSave, boolean methodHasIgnore) {
+
+        // default to save
+        boolean saveError = options.containsKey(LibraryOption.SaveError) || !options.containsKey(LibraryOption.IgnoreError);
+
+        // toggle only according to above matrix
+        if (saveError) {
+            if (methodHasIgnore && !methodHasSave) {
+                saveError = false;
+            }
+        } else {
+            if (methodHasSave) {
+                saveError = true;
+            }
+        }
+
+        return saveError;
+    }
+
+    /**
      * Adds a library to be loaded.  Multiple libraries can be specified using additional calls
      * to this method, and all libraries will be searched to resolve symbols (e.g. functions, variables).
      *

--- a/src/main/java/jnr/ffi/LibraryOption.java
+++ b/src/main/java/jnr/ffi/LibraryOption.java
@@ -18,6 +18,8 @@
 
 package jnr.ffi;
 
+import java.util.Map;
+
 /**
  * Options that apply to a library
  */
@@ -26,12 +28,17 @@ public enum LibraryOption {
      * Function calls should save the errno/last error after the call.
      * This option can be overridden on individual methods by use of the 
      * {@link jnr.ffi.annotations.IgnoreError} annotation.
+     *
+     * @see LibraryLoader#saveError(Map, boolean, boolean)
      */
     SaveError,
+
     /**
      * Function calls should NOT save the errno/last error after the call.
      * This option can be overridden on individual methods by use of the 
      * {@link jnr.ffi.annotations.SaveError} annotation.
+     *
+     * @see LibraryLoader#saveError(Map, boolean, boolean)
      */
     IgnoreError,
     

--- a/src/main/java/jnr/ffi/annotations/IgnoreError.java
+++ b/src/main/java/jnr/ffi/annotations/IgnoreError.java
@@ -18,8 +18,12 @@
 
 package jnr.ffi.annotations;
 
+import jnr.ffi.LibraryLoader;
+import jnr.ffi.LibraryOption;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
 
 /**
  * Indicates that the errno value for a native function need not be saved after
@@ -37,6 +41,7 @@ import java.lang.annotation.RetentionPolicy;
  * avoid unneccessary saving of the errno value.
  *
  * @see SaveError
+ * @see LibraryLoader#saveError(Map, boolean, boolean)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface IgnoreError {

--- a/src/main/java/jnr/ffi/annotations/SaveError.java
+++ b/src/main/java/jnr/ffi/annotations/SaveError.java
@@ -18,14 +18,19 @@
 
 package jnr.ffi.annotations;
 
+import jnr.ffi.LibraryLoader;
+import jnr.ffi.LibraryOption;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.Map;
 
 /**
  * Tags a library method as requiring any error codes as returned
  * by errno on unix, or GetLastError on windows be saved.
  *
  * @see IgnoreError
+ * @see LibraryLoader#saveError(Map, boolean, boolean)
  */
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SaveError {

--- a/src/main/java/jnr/ffi/provider/NativeFunction.java
+++ b/src/main/java/jnr/ffi/provider/NativeFunction.java
@@ -32,20 +32,16 @@ public final class NativeFunction {
     private final Method method;
     private final Collection<Annotation> annotations;
     private final boolean saveError;
+    private final boolean ignoreError;
     private final CallingConvention callingConvention;
 
     public NativeFunction(Method method, CallingConvention callingConvention) {
         this.method = method;
         this.annotations = Collections.unmodifiableCollection(Arrays.asList(method.getAnnotations()));
-        boolean saveError = true;
-        for (Annotation a : annotations) {
-            if (a instanceof IgnoreError) {
-                saveError = false;
-            } else if (a instanceof SaveError) {
-                saveError = true;
-            }
-        }
-        this.saveError = saveError;
+
+        this.saveError = hasSaveError(method);
+        this.ignoreError = hasIgnoreError(method);
+
         this.callingConvention = callingConvention;
     }
 
@@ -62,10 +58,26 @@ public final class NativeFunction {
     }
     
     public boolean isErrnoRequired() {
+        return !ignoreError || saveError;
+    }
+
+    public boolean hasSaveError() {
         return saveError;
+    }
+
+    public boolean hasIgnoreError() {
+        return ignoreError;
     }
 
     public Method getMethod() {
         return method;
+    }
+
+    public static boolean hasSaveError(Method method) {
+        return method.getAnnotation(SaveError.class) != null;
+    }
+
+    public static boolean hasIgnoreError(Method method) {
+        return method.getAnnotation(IgnoreError.class) != null;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
@@ -128,12 +128,14 @@ public class AsmLibraryLoader extends LibraryLoader {
 
                 ParameterType[] parameterTypes = getParameterTypes(runtime, typeMapper, function.getMethod());
 
+                boolean saveError = jnr.ffi.LibraryLoader.saveError(libraryOptions, function.hasSaveError(), function.hasIgnoreError());
+
                 Function jffiFunction = new Function(functionAddress, 
-                        getCallContext(resultType, parameterTypes,function.convention(), function.isErrnoRequired())); 
+                        getCallContext(resultType, parameterTypes,function.convention(), saveError));
 
                 for (MethodGenerator g : generators) {
                     if (g.isSupported(resultType, parameterTypes, function.convention())) {
-                        g.generate(builder, function.getMethod().getName(), jffiFunction, resultType, parameterTypes, !function.isErrnoRequired());
+                        g.generate(builder, function.getMethod().getName(), jffiFunction, resultType, parameterTypes, !saveError);
                         break;
                     }
                 }

--- a/src/main/java/jnr/ffi/provider/jffi/InvokerUtil.java
+++ b/src/main/java/jnr/ffi/provider/jffi/InvokerUtil.java
@@ -28,6 +28,7 @@ import jnr.ffi.annotations.IgnoreError;
 import jnr.ffi.annotations.SaveError;
 import jnr.ffi.annotations.StdCall;
 import jnr.ffi.mapper.*;
+import jnr.ffi.provider.NativeFunction;
 import jnr.ffi.provider.ParameterType;
 import jnr.ffi.provider.ResultType;
 import jnr.ffi.provider.SigType;
@@ -41,18 +42,6 @@ import java.util.EnumMap;
 import java.util.Map;
 
 final class InvokerUtil {
-
-    public static boolean requiresErrno(Method method) {
-        boolean saveError = true;
-        for (Annotation a : method.getAnnotations()) {
-            if (a instanceof IgnoreError) {
-                saveError = false;
-            } else if (a instanceof SaveError) {
-                saveError = true;
-            }
-        }
-        return saveError;
-    }
 
     public static jnr.ffi.CallingConvention getCallingConvention(Map<LibraryOption, ?> libraryOptions) {
         Object convention = libraryOptions.get(LibraryOption.CallingConvention);

--- a/src/main/java/jnr/ffi/provider/jffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/LibraryLoader.java
@@ -19,9 +19,11 @@
 package jnr.ffi.provider.jffi;
 
 import jnr.ffi.LibraryOption;
+import jnr.ffi.provider.NativeFunction;
 
 import java.util.Map;
 
 public abstract class LibraryLoader {
+
     abstract <T> T loadLibrary(NativeLibrary library, Class<T> interfaceClass, Map<LibraryOption, ?> libraryOptions);
 }

--- a/src/main/java/jnr/ffi/provider/jffi/ReflectionLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/ReflectionLibraryLoader.java
@@ -180,8 +180,11 @@ class ReflectionLibraryLoader extends LibraryLoader {
             CallingConvention callingConvention = method.isAnnotationPresent(StdCall.class)
                     ? CallingConvention.STDCALL : libraryCallingConvention;
 
+            // If ignore has been specified and save error has not, ignore error; otherwise, library default
+            boolean saveError = jnr.ffi.LibraryLoader.saveError(libraryOptions, NativeFunction.hasSaveError(method), NativeFunction.hasIgnoreError(method));
+
             Function function = new Function(functionAddress,
-                    getCallContext(resultType, parameterTypes, callingConvention, InvokerUtil.requiresErrno(method)));
+                    getCallContext(resultType, parameterTypes, callingConvention, saveError));
 
             Invoker invoker = invokerFactory.createInvoker(runtime, library, function, resultType, parameterTypes);
 


### PR DESCRIPTION
* SaveError and IgnoreError library options are now honored. The
  default if neither is specified is to save.
* If both SaveError and IgnoreError options or both annotations
  are used at the same time on the same element (class or method),
  save wins (since it has only a small performance effect if the
  save is unwanted, but serious problems if the save is wanted but
  not performed).
* Only the following cases will ignore error:
  1. Ignore option is specified, save option is not specified,
     and method does not specify either annotation.
  2. Ignore annotation is specified and save annotation is not.
* Centralize logic and document matrix.
* Test all combinations in the matrix.