### PR TITLE
Enable support for Aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.2.11</version>
+      <version>1.2.13</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.2.11</version>
+      <version>1.2.13</version>
       <scope>runtime</scope>
       <classifier>native</classifier>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,13 +55,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.13-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.2.13</version>
+      <version>1.2.13-SNAPSHOT</version>
       <scope>runtime</scope>
       <classifier>native</classifier>
     </dependency>

--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -113,6 +113,9 @@ public abstract class Platform {
         /** 32 bit ARM */
         ARM,
 
+        /** 64 bit ARM */
+        AARCH64,
+
         /**
          * Unknown CPU architecture.  A best effort will be made to infer architecture
          * specific values such as address and long size.
@@ -208,6 +211,8 @@ public abstract class Platform {
             return CPU.PPC64LE;
         } else if (equalsIgnoreCase("s390", archString) || equalsIgnoreCase("s390x", archString)) {
             return CPU.S390X;
+        } else if (equalsIgnoreCase("aarch64", archString)) {
+            return CPU.AARCH64;
         }
 
         // Try to find by lookup up in the CPU list
@@ -264,6 +269,7 @@ public abstract class Platform {
                 case PPC64LE:
                 case SPARCV9:
                 case S390X:
+                case AARCH64:
                     dataModel = 64;
                     break;
                 default:

--- a/src/main/java/jnr/ffi/provider/jffi/platform/aarch64/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/aarch64/linux/TypeAliases.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.ffi.provider.jffi.platform.aarch64.linux;
+
+import jnr.ffi.NativeType;
+import jnr.ffi.TypeAlias;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class TypeAliases {
+    public static final Map<TypeAlias, jnr.ffi.NativeType> ALIASES = buildTypeMap();
+    private static Map<TypeAlias, jnr.ffi.NativeType> buildTypeMap() {
+        Map<TypeAlias, jnr.ffi.NativeType> m = new EnumMap<TypeAlias, jnr.ffi.NativeType>(TypeAlias.class);
+        m.put(TypeAlias.int8_t, NativeType.SCHAR);
+        m.put(TypeAlias.u_int8_t, NativeType.UCHAR);
+        m.put(TypeAlias.int16_t, NativeType.SSHORT);
+        m.put(TypeAlias.u_int16_t, NativeType.USHORT);
+        m.put(TypeAlias.int32_t, NativeType.SINT);
+        m.put(TypeAlias.u_int32_t, NativeType.UINT);
+        m.put(TypeAlias.int64_t, NativeType.ADDRESS);
+        m.put(TypeAlias.u_int64_t, NativeType.ADDRESS);
+        m.put(TypeAlias.intptr_t, NativeType.SLONG);
+        m.put(TypeAlias.uintptr_t, NativeType.ULONG);
+        m.put(TypeAlias.caddr_t, NativeType.ADDRESS);
+        m.put(TypeAlias.dev_t, NativeType.ULONG);
+        m.put(TypeAlias.blkcnt_t, NativeType.SLONG);
+        m.put(TypeAlias.blksize_t, NativeType.SLONG);
+        m.put(TypeAlias.gid_t, NativeType.UINT);
+        m.put(TypeAlias.in_addr_t, NativeType.UINT);
+        m.put(TypeAlias.in_port_t, NativeType.USHORT);
+        m.put(TypeAlias.ino_t, NativeType.ULONG);
+        m.put(TypeAlias.ino64_t, NativeType.ULONG);
+        m.put(TypeAlias.key_t, NativeType.SINT);
+        m.put(TypeAlias.mode_t, NativeType.UINT);
+        m.put(TypeAlias.nlink_t, NativeType.ULONG);
+        m.put(TypeAlias.id_t, NativeType.UINT);
+        m.put(TypeAlias.pid_t, NativeType.SINT);
+        m.put(TypeAlias.off_t, NativeType.SLONG);
+        m.put(TypeAlias.swblk_t, NativeType.SLONG);
+        m.put(TypeAlias.uid_t, NativeType.UINT);
+        m.put(TypeAlias.clock_t, NativeType.SLONG);
+        m.put(TypeAlias.size_t, NativeType.ULONG);
+        m.put(TypeAlias.ssize_t, NativeType.SLONG);
+        m.put(TypeAlias.time_t, NativeType.SLONG);
+        m.put(TypeAlias.fsblkcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.fsfilcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.sa_family_t, NativeType.USHORT);
+        m.put(TypeAlias.socklen_t, NativeType.UINT);
+        m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        return m;
+    }
+}


### PR DESCRIPTION
Add the configuration for 64-bit ARM (AArch64).
Updates dependency on jffi to version 1.2.13 for AArch64 support there.