### PR TITLE
Fix inner struct alignment when alignment value is not default

### DIFF
--- a/libtest/StructTest.c
+++ b/libtest/StructTest.c
@@ -91,35 +91,132 @@ fill_struct_from_longs(unsigned long l1, unsigned long l2, struct foo* s, unsign
   return 0;
 }
 
-#define STRUCT_ALIGNMENT(alignment)             \
-    struct StructAlignment##alignment {         \
-        uint8_t  f0;                            \
-        uint16_t f1;                            \
-        uint32_t f2;                            \
-        uint64_t f3;                            \
-        void    *f4;                            \
-        };                                      \
-                                                \
-    int struct_alignment_size_##alignment() {                           \
-        return sizeof(struct StructAlignment##alignment);               \
-    }                                                                   \
-                                                                        \
-    int struct_alignment_field_offset_##alignment(int field) {          \
-        switch(field) {                                                 \
-        case 0:                                                         \
-            return offsetof(struct StructAlignment##alignment, f0);     \
-        case 1:                                                         \
-            return offsetof(struct StructAlignment##alignment, f1);     \
-        case 2:                                                         \
-            return offsetof(struct StructAlignment##alignment, f2);     \
-        case 3:                                                         \
-            return offsetof(struct StructAlignment##alignment, f3);     \
-        case 4:                                                         \
-            return offsetof(struct StructAlignment##alignment, f4);     \
-        default:                                                        \
-            return -1;                                                  \
-        }                                                               \
-    }                                                                   \
+#define STRUCT_ALIGNMENT(alignment)                                                   \
+    struct StructAlignment##alignment {                                               \
+        uint8_t  f0;                                                                  \
+        uint16_t f1;                                                                  \
+        uint32_t f2;                                                                  \
+        uint64_t f3;                                                                  \
+        void    *f4;                                                                  \
+        };                                                                            \
+                                                                                      \
+    int struct_alignment_size_##alignment() {                                         \
+        return sizeof(struct StructAlignment##alignment);                             \
+    }                                                                                 \
+                                                                                      \
+    int struct_alignment_field_offset_##alignment(int field) {                        \
+        switch(field) {                                                               \
+        case 0:                                                                       \
+            return offsetof(struct StructAlignment##alignment, f0);                   \
+        case 1:                                                                       \
+            return offsetof(struct StructAlignment##alignment, f1);                   \
+        case 2:                                                                       \
+            return offsetof(struct StructAlignment##alignment, f2);                   \
+        case 3:                                                                       \
+            return offsetof(struct StructAlignment##alignment, f3);                   \
+        case 4:                                                                       \
+            return offsetof(struct StructAlignment##alignment, f4);                   \
+        default:                                                                      \
+            return -1;                                                                \
+        }                                                                             \
+    }                                                                                 \
+                                                                                      \
+    struct InnerStructAlignment1_##alignment {                                        \
+        uint8_t  f0;                                                                  \
+        uint16_t f1;                                                                  \
+        uint32_t f2;                                                                  \
+        uint64_t f3;                                                                  \
+        void    *f4;                                                                  \
+        struct InnerStructAlignment2_##alignment {                                    \
+            uint8_t  f0;                                                              \
+            uint16_t f1;                                                              \
+            uint32_t f2;                                                              \
+            uint64_t f3;                                                              \
+            void    *f4;                                                              \
+            struct InnerStructAlignment3_##alignment {                                \
+                uint8_t  f0;                                                          \
+                uint16_t f1;                                                          \
+                uint32_t f2;                                                          \
+                uint64_t f3;                                                          \
+                void    *f4;                                                          \
+            } f5;                                                                     \
+        } f5;                                                                         \
+    };                                                                                \
+                                                                                      \
+    int inner_struct_alignment_size_##alignment() {                                   \
+        return sizeof(struct InnerStructAlignment1_##alignment);                      \
+    }                                                                                 \
+                                                                                      \
+    int inner_struct_alignment_field_offset_##alignment(int level, int field) {       \
+        switch(field) {                                                               \
+        case 0:                                                                       \
+            switch(level) {                                                           \
+            case 0:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f0);        \
+            case 1:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f0);     \
+            case 2:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f5.f0);  \
+            default:                                                                  \
+                return -1;                                                            \
+            }                                                                         \
+        case 1:                                                                       \
+            switch(level) {                                                           \
+            case 0:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f1);        \
+            case 1:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f1);     \
+            case 2:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f5.f1);  \
+            default:                                                                  \
+                return -1;                                                            \
+            }                                                                         \
+        case 2:                                                                       \
+            switch(level) {                                                           \
+            case 0:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f2);        \
+            case 1:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f2);     \
+            case 2:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f5.f2);  \
+            default:                                                                  \
+                return -1;                                                            \
+            }                                                                         \
+        case 3:                                                                       \
+            switch(level) {                                                           \
+            case 0:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f3);        \
+            case 1:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f3);     \
+            case 2:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f5.f3);  \
+            default:                                                                  \
+                return -1;                                                            \
+            }                                                                         \
+        case 4:                                                                       \
+            switch(level) {                                                           \
+            case 0:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f4);        \
+            case 1:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f4);     \
+            case 2:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f5.f4);  \
+            default:                                                                  \
+                return -1;                                                            \
+            }                                                                         \
+        case 5:                                                                       \
+            switch(level) {                                                           \
+            case 0:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5);        \
+            case 1:                                                                   \
+                return offsetof(struct InnerStructAlignment1_##alignment, f5.f5);     \
+            default:                                                                  \
+                return -1;                                                            \
+            }                                                                         \
+        default:                                                                      \
+            return -1;                                                                \
+        }                                                                             \
+    }
 
 #pragma pack(push, 1)
 STRUCT_ALIGNMENT(1)

--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -126,6 +126,11 @@ public abstract class Struct {
         __info.alignment = alignment;
     }
 
+    protected Struct(Runtime runtime, Struct enclosing) {
+        this(runtime);
+        __info.alignment = enclosing.__info.alignment;
+    }
+
     /**
      * Creates a new <tt>Struct</tt>.
      *
@@ -661,10 +666,11 @@ public abstract class Struct {
     }
 
     protected final <T extends Struct> T inner(T struct) {
-        int off = __info.resetIndex ? 0 : align(__info.size, struct.__info.getMinimumAlignment());
+        int alignment = __info.alignment.intValue() > 0 ? Math.min(__info.alignment.intValue(), struct.__info.getMinimumAlignment()) : struct.__info.getMinimumAlignment();
+        int offset = __info.resetIndex ? 0 : align(__info.size, alignment);
         struct.__info.enclosing = this;
-        struct.__info.offset = off;
-        __info.size = Math.max(__info.size, off + struct.__info.size);
+        struct.__info.offset = offset;
+        __info.size = Math.max(__info.size, offset + struct.__info.size);
         return struct;
     }
 

--- a/src/test/java/jnr/ffi/struct/AlignmentTest.java
+++ b/src/test/java/jnr/ffi/struct/AlignmentTest.java
@@ -74,6 +74,64 @@ public class AlignmentTest {
         public int struct_alignment_size_16();
 
         public int struct_alignment_field_offset_16(int field);
+
+        class InnerStructAlignment1 extends Struct {
+            class InnerStructAlignment2 extends Struct {
+                class InnerStructAlignment3 extends Struct {
+                    public final u_int8_t  f0 = new u_int8_t();
+                    public final u_int16_t f1 = new u_int16_t();
+                    public final u_int32_t f2 = new u_int32_t();
+                    public final u_int64_t f3 = new u_int64_t();
+                    public final Pointer   f4 = new Pointer();
+
+                    public InnerStructAlignment3(Struct enclosing) {
+                        super(runtime, enclosing);
+                    }
+                }
+
+                public final u_int8_t              f0 = new u_int8_t();
+                public final u_int16_t             f1 = new u_int16_t();
+                public final u_int32_t             f2 = new u_int32_t();
+                public final u_int64_t             f3 = new u_int64_t();
+                public final Pointer               f4 = new Pointer();
+                public final InnerStructAlignment3 f5 = inner(new InnerStructAlignment3(this));
+
+                public InnerStructAlignment2(Struct enclosing) {
+                    super(runtime, enclosing);
+                }
+            }
+
+            public final u_int8_t              f0 = new u_int8_t();
+            public final u_int16_t             f1 = new u_int16_t();
+            public final u_int32_t             f2 = new u_int32_t();
+            public final u_int64_t             f3 = new u_int64_t();
+            public final Pointer               f4 = new Pointer();
+            public final InnerStructAlignment2 f5 = inner(new InnerStructAlignment2(this));
+
+            public InnerStructAlignment1(Alignment alignment) {
+                super(runtime, alignment);
+            }
+        }
+
+        int inner_struct_alignment_size_1();
+
+        int inner_struct_alignment_field_offset_1(int level, int field);
+
+        int inner_struct_alignment_size_2();
+
+        int inner_struct_alignment_field_offset_2(int level, int field);
+
+        int inner_struct_alignment_size_4();
+
+        int inner_struct_alignment_field_offset_4(int level, int field);
+
+        int inner_struct_alignment_size_8();
+
+        int inner_struct_alignment_field_offset_8(int level, int field);
+
+        int inner_struct_alignment_size_16();
+
+        int inner_struct_alignment_field_offset_16(int level, int field);
     }
 
     static TestLib testlib;
@@ -170,5 +228,115 @@ public class AlignmentTest {
         assertEquals("f2 offset", testlib.struct_alignment_field_offset_16(2), s.f2.offset());
         assertEquals("f3 offset", testlib.struct_alignment_field_offset_16(3), s.f3.offset());
         assertEquals("f4 offset", testlib.struct_alignment_field_offset_16(4), s.f4.offset());
+    }
+
+    @Test
+    public void alignsInnerStructWhenTheAlignmentValueIs1() {
+        TestLib.InnerStructAlignment1 s = new TestLib.InnerStructAlignment1(new Struct.Alignment(1));
+
+        assertEquals("InnerStructAlignment1 size", testlib.inner_struct_alignment_size_1(), Struct.size(s));
+        assertEquals("f0 offset"      , testlib.inner_struct_alignment_field_offset_1(0, 0), s.f0.offset());
+        assertEquals("f1 offset"      , testlib.inner_struct_alignment_field_offset_1(0, 1), s.f1.offset());
+        assertEquals("f2 offset"      , testlib.inner_struct_alignment_field_offset_1(0, 2), s.f2.offset());
+        assertEquals("f3 offset"      , testlib.inner_struct_alignment_field_offset_1(0, 3), s.f3.offset());
+        assertEquals("f4 offset"      , testlib.inner_struct_alignment_field_offset_1(0, 4), s.f4.offset());
+        assertEquals("f5.f0 offset"   , testlib.inner_struct_alignment_field_offset_1(1, 0), s.f5.f0.offset());
+        assertEquals("f5.f1 offset"   , testlib.inner_struct_alignment_field_offset_1(1, 1), s.f5.f1.offset());
+        assertEquals("f5.f2 offset"   , testlib.inner_struct_alignment_field_offset_1(1, 2), s.f5.f2.offset());
+        assertEquals("f5.f3 offset"   , testlib.inner_struct_alignment_field_offset_1(1, 3), s.f5.f3.offset());
+        assertEquals("f5.f4 offset"   , testlib.inner_struct_alignment_field_offset_1(1, 4), s.f5.f4.offset());
+        assertEquals("f5.f5.f0 offset", testlib.inner_struct_alignment_field_offset_1(2, 0), s.f5.f5.f0.offset());
+        assertEquals("f5.f5.f1 offset", testlib.inner_struct_alignment_field_offset_1(2, 1), s.f5.f5.f1.offset());
+        assertEquals("f5.f5.f2 offset", testlib.inner_struct_alignment_field_offset_1(2, 2), s.f5.f5.f2.offset());
+        assertEquals("f5.f5.f3 offset", testlib.inner_struct_alignment_field_offset_1(2, 3), s.f5.f5.f3.offset());
+        assertEquals("f5.f5.f4 offset", testlib.inner_struct_alignment_field_offset_1(2, 4), s.f5.f5.f4.offset());
+    }
+
+    @Test
+    public void alignsInnerStructWhenTheAlignmentValueIs2() {
+        TestLib.InnerStructAlignment1 s = new TestLib.InnerStructAlignment1(new Struct.Alignment(2));
+
+        assertEquals("InnerStructAlignment2 size", testlib.inner_struct_alignment_size_2(), Struct.size(s));
+        assertEquals("f0 offset"      , testlib.inner_struct_alignment_field_offset_2(0, 0), s.f0.offset());
+        assertEquals("f1 offset"      , testlib.inner_struct_alignment_field_offset_2(0, 1), s.f1.offset());
+        assertEquals("f2 offset"      , testlib.inner_struct_alignment_field_offset_2(0, 2), s.f2.offset());
+        assertEquals("f3 offset"      , testlib.inner_struct_alignment_field_offset_2(0, 3), s.f3.offset());
+        assertEquals("f4 offset"      , testlib.inner_struct_alignment_field_offset_2(0, 4), s.f4.offset());
+        assertEquals("f5.f0 offset"   , testlib.inner_struct_alignment_field_offset_2(1, 0), s.f5.f0.offset());
+        assertEquals("f5.f1 offset"   , testlib.inner_struct_alignment_field_offset_2(1, 1), s.f5.f1.offset());
+        assertEquals("f5.f2 offset"   , testlib.inner_struct_alignment_field_offset_2(1, 2), s.f5.f2.offset());
+        assertEquals("f5.f3 offset"   , testlib.inner_struct_alignment_field_offset_2(1, 3), s.f5.f3.offset());
+        assertEquals("f5.f4 offset"   , testlib.inner_struct_alignment_field_offset_2(1, 4), s.f5.f4.offset());
+        assertEquals("f5.f5.f0 offset", testlib.inner_struct_alignment_field_offset_2(2, 0), s.f5.f5.f0.offset());
+        assertEquals("f5.f5.f1 offset", testlib.inner_struct_alignment_field_offset_2(2, 1), s.f5.f5.f1.offset());
+        assertEquals("f5.f5.f2 offset", testlib.inner_struct_alignment_field_offset_2(2, 2), s.f5.f5.f2.offset());
+        assertEquals("f5.f5.f3 offset", testlib.inner_struct_alignment_field_offset_2(2, 3), s.f5.f5.f3.offset());
+        assertEquals("f5.f5.f4 offset", testlib.inner_struct_alignment_field_offset_2(2, 4), s.f5.f5.f4.offset());
+    }
+
+    @Test
+    public void alignsInnerStructWhenTheAlignmentValueIs4() {
+        TestLib.InnerStructAlignment1 s = new TestLib.InnerStructAlignment1(new Struct.Alignment(4));
+
+        assertEquals("InnerStructAlignment4 size", testlib.inner_struct_alignment_size_4(), Struct.size(s));
+        assertEquals("f1 offset"      , testlib.inner_struct_alignment_field_offset_4(0, 1), s.f1.offset());
+        assertEquals("f0 offset"      , testlib.inner_struct_alignment_field_offset_4(0, 0), s.f0.offset());
+        assertEquals("f2 offset"      , testlib.inner_struct_alignment_field_offset_4(0, 2), s.f2.offset());
+        assertEquals("f3 offset"      , testlib.inner_struct_alignment_field_offset_4(0, 3), s.f3.offset());
+        assertEquals("f4 offset"      , testlib.inner_struct_alignment_field_offset_4(0, 4), s.f4.offset());
+        assertEquals("f5.f0 offset"   , testlib.inner_struct_alignment_field_offset_4(1, 0), s.f5.f0.offset());
+        assertEquals("f5.f1 offset"   , testlib.inner_struct_alignment_field_offset_4(1, 1), s.f5.f1.offset());
+        assertEquals("f5.f2 offset"   , testlib.inner_struct_alignment_field_offset_4(1, 2), s.f5.f2.offset());
+        assertEquals("f5.f3 offset"   , testlib.inner_struct_alignment_field_offset_4(1, 3), s.f5.f3.offset());
+        assertEquals("f5.f4 offset"   , testlib.inner_struct_alignment_field_offset_4(1, 4), s.f5.f4.offset());
+        assertEquals("f5.f5.f0 offset", testlib.inner_struct_alignment_field_offset_4(2, 0), s.f5.f5.f0.offset());
+        assertEquals("f5.f5.f1 offset", testlib.inner_struct_alignment_field_offset_4(2, 1), s.f5.f5.f1.offset());
+        assertEquals("f5.f5.f2 offset", testlib.inner_struct_alignment_field_offset_4(2, 2), s.f5.f5.f2.offset());
+        assertEquals("f5.f5.f3 offset", testlib.inner_struct_alignment_field_offset_4(2, 3), s.f5.f5.f3.offset());
+        assertEquals("f5.f5.f4 offset", testlib.inner_struct_alignment_field_offset_4(2, 4), s.f5.f5.f4.offset());
+    }
+
+    @Test
+    public void alignsInnerStructWhenTheAlignmentValueIs8() {
+        TestLib.InnerStructAlignment1 s = new TestLib.InnerStructAlignment1(new Struct.Alignment(8));
+
+        assertEquals("InnerStructAlignment8 size", testlib.inner_struct_alignment_size_8(), Struct.size(s));
+        assertEquals("f1 offset"      , testlib.inner_struct_alignment_field_offset_8(0, 1), s.f1.offset());
+        assertEquals("f0 offset"      , testlib.inner_struct_alignment_field_offset_8(0, 0), s.f0.offset());
+        assertEquals("f2 offset"      , testlib.inner_struct_alignment_field_offset_8(0, 2), s.f2.offset());
+        assertEquals("f3 offset"      , testlib.inner_struct_alignment_field_offset_8(0, 3), s.f3.offset());
+        assertEquals("f4 offset"      , testlib.inner_struct_alignment_field_offset_8(0, 4), s.f4.offset());
+        assertEquals("f5.f0 offset"   , testlib.inner_struct_alignment_field_offset_8(1, 0), s.f5.f0.offset());
+        assertEquals("f5.f1 offset"   , testlib.inner_struct_alignment_field_offset_8(1, 1), s.f5.f1.offset());
+        assertEquals("f5.f2 offset"   , testlib.inner_struct_alignment_field_offset_8(1, 2), s.f5.f2.offset());
+        assertEquals("f5.f3 offset"   , testlib.inner_struct_alignment_field_offset_8(1, 3), s.f5.f3.offset());
+        assertEquals("f5.f4 offset"   , testlib.inner_struct_alignment_field_offset_8(1, 4), s.f5.f4.offset());
+        assertEquals("f5.f5.f0 offset", testlib.inner_struct_alignment_field_offset_8(2, 0), s.f5.f5.f0.offset());
+        assertEquals("f5.f5.f1 offset", testlib.inner_struct_alignment_field_offset_8(2, 1), s.f5.f5.f1.offset());
+        assertEquals("f5.f5.f2 offset", testlib.inner_struct_alignment_field_offset_8(2, 2), s.f5.f5.f2.offset());
+        assertEquals("f5.f5.f3 offset", testlib.inner_struct_alignment_field_offset_8(2, 3), s.f5.f5.f3.offset());
+        assertEquals("f5.f5.f4 offset", testlib.inner_struct_alignment_field_offset_8(2, 4), s.f5.f5.f4.offset());
+    }
+
+    @Test
+    public void alignsInnerStructWhenTheAlignmentValueIs16() {
+        TestLib.InnerStructAlignment1 s = new TestLib.InnerStructAlignment1(new Struct.Alignment(16));
+
+        assertEquals("InnerStructAlignment16 size", testlib.inner_struct_alignment_size_16(), Struct.size(s));
+        assertEquals("f1 offset"      , testlib.inner_struct_alignment_field_offset_16(0, 1), s.f1.offset());
+        assertEquals("f0 offset"      , testlib.inner_struct_alignment_field_offset_16(0, 0), s.f0.offset());
+        assertEquals("f2 offset"      , testlib.inner_struct_alignment_field_offset_16(0, 2), s.f2.offset());
+        assertEquals("f3 offset"      , testlib.inner_struct_alignment_field_offset_16(0, 3), s.f3.offset());
+        assertEquals("f4 offset"      , testlib.inner_struct_alignment_field_offset_16(0, 4), s.f4.offset());
+        assertEquals("f5.f0 offset"   , testlib.inner_struct_alignment_field_offset_16(1, 0), s.f5.f0.offset());
+        assertEquals("f5.f1 offset"   , testlib.inner_struct_alignment_field_offset_16(1, 1), s.f5.f1.offset());
+        assertEquals("f5.f2 offset"   , testlib.inner_struct_alignment_field_offset_16(1, 2), s.f5.f2.offset());
+        assertEquals("f5.f3 offset"   , testlib.inner_struct_alignment_field_offset_16(1, 3), s.f5.f3.offset());
+        assertEquals("f5.f4 offset"   , testlib.inner_struct_alignment_field_offset_16(1, 4), s.f5.f4.offset());
+        assertEquals("f5.f5.f0 offset", testlib.inner_struct_alignment_field_offset_16(2, 0), s.f5.f5.f0.offset());
+        assertEquals("f5.f5.f1 offset", testlib.inner_struct_alignment_field_offset_16(2, 1), s.f5.f5.f1.offset());
+        assertEquals("f5.f5.f2 offset", testlib.inner_struct_alignment_field_offset_16(2, 2), s.f5.f5.f2.offset());
+        assertEquals("f5.f5.f3 offset", testlib.inner_struct_alignment_field_offset_16(2, 3), s.f5.f5.f3.offset());
+        assertEquals("f5.f5.f4 offset", testlib.inner_struct_alignment_field_offset_16(2, 4), s.f5.f5.f4.offset());
     }
 }


### PR DESCRIPTION
This pull request is a complement/fix for pull request #46.