### PR TITLE
Allow overriding make in maven using -Dmake=...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <maven.compiler.target>1.6</maven.compiler.target>
     <github.global.server>github</github.global.server>
     <asm.version>5.0.3</asm.version>
+    <make>make</make>
   </properties>
 
   <dependencies>
@@ -112,7 +113,7 @@
             <phase>test-compile</phase>
             <configuration>
               <tasks>
-                <exec dir="${basedir}" executable="make" failonerror="true">
+                  <exec dir="${basedir}" executable="${make}" failonerror="true">
                   <arg line="-f libtest/GNUmakefile" />
                   <arg line="BUILD_DIR=${project.build.directory}" />
                   <arg line="CPU=${os.arch}" />


### PR DESCRIPTION
On systems where make ist not a GNU make flavor (like bsdmake or others). The build fails, because of the use of GNU-specific features in GNUmakefile. On those systems, there is usually a GNU make available, but it is named like gmake. The current pom.xml however has the name hardcoded. This PR enables easily changing the name of make on the mvn cmdline. E.g.:

mvn -Dmake=gmake package

