### PR TITLE
Permit Struct.Function.set() to be called from outside a Struct: #87

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-ffi</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.1</version>
+  <version>2.1.2-SNAPSHOT</version>
   <name>jnr-ffi</name>
   <description>A library for invoking native functions from java</description>
   <url>http://github.com/jnr/jnr-ffi</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>com.github.jnr</groupId>
   <artifactId>jnr-ffi</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.1.1</version>
   <name>jnr-ffi</name>
   <description>A library for invoking native functions from java</description>
   <url>http://github.com/jnr/jnr-ffi</url>

--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -2151,7 +2151,7 @@ public abstract class Struct {
         }
     }
 
-    protected final class Function<T> extends AbstractMember {
+    public final class Function<T> extends AbstractMember {
         private final Class<? extends T> closureClass;
         private T instance;
 


### PR DESCRIPTION
Make Struct.Function public in Struct so that a public member can
be set() from outside of Struct.