### PR TITLE
Override toString() in Unsigned32 and IntegerAlias to fix #94.

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -904,9 +904,9 @@ public abstract class Struct {
         }
 
         /**
-         * Returns a string representation of this <code>Address</code>.
+         * Returns a string representation of this <code>Number</code>.
          *
-         * @return a string representation of this <code>Address</code>.
+         * @return a string representation of this <code>Number</code>.
          */
         @Override
         public java.lang.String toString() {
@@ -950,6 +950,16 @@ public abstract class Struct {
         @Override
         public long longValue() {
             return get();
+        }
+
+        /**
+         * Returns a string representation of this field.
+         *
+         * @return a string representation of this field.
+         */
+        @Override
+        public final java.lang.String toString() {
+            return java.lang.Long.toString(get());
         }
     }
 
@@ -1321,6 +1331,16 @@ public abstract class Struct {
         @Override
         public final long longValue() {
             return get();
+        }
+
+        /**
+         * Returns a string representation of this field.
+         *
+         * @return a string representation of this field.
+         */
+        @Override
+        public final java.lang.String toString() {
+            return java.lang.Long.toString(get());
         }
     }
 

--- a/src/main/java/jnr/ffi/provider/jffi/platform/sparc/solaris/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/sparc/solaris/TypeAliases.java
@@ -42,7 +42,7 @@ public final class TypeAliases {
         m.put(TypeAlias.dev_t, NativeType.ULONG);
         m.put(TypeAlias.blkcnt_t, NativeType.SLONGLONG);
         m.put(TypeAlias.blksize_t, NativeType.SLONG);
-        m.put(TypeAlias.gid_t, NativeType.SLONG);
+        m.put(TypeAlias.gid_t, NativeType.UINT);
         m.put(TypeAlias.in_addr_t, NativeType.UINT);
         m.put(TypeAlias.in_port_t, NativeType.USHORT);
         m.put(TypeAlias.ino_t, NativeType.ULONGLONG);
@@ -54,7 +54,7 @@ public final class TypeAliases {
         m.put(TypeAlias.pid_t, NativeType.SLONG);
         m.put(TypeAlias.off_t, NativeType.SLONGLONG);
         m.put(TypeAlias.swblk_t, NativeType.SLONG);
-        m.put(TypeAlias.uid_t, NativeType.SLONG);
+        m.put(TypeAlias.uid_t, NativeType.UINT);
         m.put(TypeAlias.clock_t, NativeType.SLONG);
         m.put(TypeAlias.size_t, NativeType.UINT);
         m.put(TypeAlias.ssize_t, NativeType.SINT);

--- a/src/main/java/jnr/ffi/provider/jffi/platform/sparcv9/solaris/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/sparcv9/solaris/TypeAliases.java
@@ -42,7 +42,7 @@ public final class TypeAliases {
         m.put(TypeAlias.dev_t, NativeType.ULONG);
         m.put(TypeAlias.blkcnt_t, NativeType.SLONGLONG);
         m.put(TypeAlias.blksize_t, NativeType.SLONG);
-        m.put(TypeAlias.gid_t, NativeType.SLONG);
+        m.put(TypeAlias.gid_t, NativeType.UINT);
         m.put(TypeAlias.in_addr_t, NativeType.UINT);
         m.put(TypeAlias.in_port_t, NativeType.USHORT);
         m.put(TypeAlias.ino_t, NativeType.ULONGLONG);
@@ -54,7 +54,7 @@ public final class TypeAliases {
         m.put(TypeAlias.pid_t, NativeType.SLONG);
         m.put(TypeAlias.off_t, NativeType.SLONGLONG);
         m.put(TypeAlias.swblk_t, NativeType.SLONG);
-        m.put(TypeAlias.uid_t, NativeType.SLONG);
+        m.put(TypeAlias.uid_t, NativeType.UINT);
         m.put(TypeAlias.clock_t, NativeType.SLONG);
         m.put(TypeAlias.size_t, NativeType.UINT);
         m.put(TypeAlias.ssize_t, NativeType.SINT);


### PR DESCRIPTION
Since NumberField.toString() downcasts to int, it needs to be overridden
for number fields bigger than int. This was handled in other places
but was missed for Unsigned32 and IntegerAlias.