### PR TITLE
Override toString() in Unsigned32 and IntegerAlias to fix #94.

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -904,9 +904,9 @@ public abstract class Struct {
         }
 
         /**
-         * Returns a string representation of this <code>Address</code>.
+         * Returns a string representation of this <code>Number</code>.
          *
-         * @return a string representation of this <code>Address</code>.
+         * @return a string representation of this <code>Number</code>.
          */
         @Override
         public java.lang.String toString() {
@@ -950,6 +950,16 @@ public abstract class Struct {
         @Override
         public long longValue() {
             return get();
+        }
+
+        /**
+         * Returns a string representation of this field.
+         *
+         * @return a string representation of this field.
+         */
+        @Override
+        public final java.lang.String toString() {
+            return java.lang.Long.toString(get());
         }
     }
 
@@ -1321,6 +1331,16 @@ public abstract class Struct {
         @Override
         public final long longValue() {
             return get();
+        }
+
+        /**
+         * Returns a string representation of this field.
+         *
+         * @return a string representation of this field.
+         */
+        @Override
+        public final java.lang.String toString() {
+            return java.lang.Long.toString(get());
         }
     }
 


### PR DESCRIPTION
Since NumberField.toString() downcasts to int, it needs to be overridden
for number fields bigger than int. This was handled in other places
but was missed for Unsigned32 and IntegerAlias.