### PR TITLE
Fix using thread in native runtime.(#51)

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/NativeRuntime.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeRuntime.java
@@ -42,7 +42,7 @@ public final class NativeRuntime extends AbstractRuntime {
     private final NativeMemoryManager mm = new NativeMemoryManager(this);
     private final NativeClosureManager closureManager = new NativeClosureManager(this,
             new SignatureTypeMapperAdapter(new DefaultTypeMapper()),
-            new AsmClassLoader(ClassLoader.getSystemClassLoader()));
+            new AsmClassLoader(Thread.currentThread().getContextClassLoader()));
     private final Type[] aliases;
 
     public static NativeRuntime getInstance() {


### PR DESCRIPTION
I use callback method of jnr-ffi. But Classnotfound is occurred in current version. I want to resolve this issue. Please accept this pull request.
This patch resolve #51.