### PR TITLE
[Do not merge] Demo for incorrect single-byte encoding handling

### DIFF
--- a/libtest/StringTest.c
+++ b/libtest/StringTest.c
@@ -18,6 +18,12 @@
 
 #include <string.h>
 
+char *
+string_static()
+{
+    return "static string";
+}
+
 int 
 string_equals(const char* s1, const char* s2)
 {

--- a/src/test/java/jnr/ffi/StringTest.java
+++ b/src/test/java/jnr/ffi/StringTest.java
@@ -35,6 +35,7 @@ public class StringTest {
     public StringTest() {
     }
     public static interface TestLib {
+        String string_static();
         boolean string_equals(String s1, String s2);
         boolean string_equals(CharSequence s1, byte[] s2);        
         void string_set(StringBuffer dst, CharSequence src);
@@ -61,7 +62,12 @@ public class StringTest {
     public void tearDown() {
     }
 
-   
+
+    @Test
+    public void testStaticString() {
+        assertEquals("static string", testlib.string_static());
+    }
+
     @Test
     public void testReadOnlyString() {
         String MAGIC = "deadbeef\u0000";


### PR DESCRIPTION
To reproduce:
- `mvn clean test -DargLine=-Dfile.encoding=windows-1251` should fail;
- `mvn clean test -DargLine=-Dfile.encoding=utf-8` should pass.