### PR TITLE
Fixed IndexOutOfBoundsException on sparse String array

### DIFF
--- a/src/main/java/jnr/ffi/provider/converters/CharSequenceArrayParameterConverter.java
+++ b/src/main/java/jnr/ffi/provider/converters/CharSequenceArrayParameterConverter.java
@@ -108,6 +108,7 @@ public class CharSequenceArrayParameterConverter implements ToNativeConverter<Ch
         void put(int idx, CharSequence str) {
             if (str == null) {
                 memory.putAddress(idx * getRuntime().addressSize(), 0L);
+                stringMemory.add(idx, null);
             } else {
                 ByteBuffer buf = charset.encode(CharBuffer.wrap(str));
                 Pointer ptr = Memory.allocateDirect(getRuntime(), buf.remaining() + 4, true);

--- a/src/test/java/jnr/ffi/StringArrayTest.java
+++ b/src/test/java/jnr/ffi/StringArrayTest.java
@@ -80,7 +80,6 @@ public class StringArrayTest {
         assertNull("last element of string array was not null", result);
     }
 
-
     @Test public void firstElementOfStringArrayShouldNotBeNull() {
         final String MAGIC = "test";
         String[] strings = { MAGIC };
@@ -100,5 +99,11 @@ public class StringArrayTest {
         ptr.putString(0, MAGIC, 1024, Charset.defaultCharset());
         testlib.ptr_set_array_element(strings, 0, ptr);
         assertEquals(MAGIC, strings[0]);
+    }
+
+    @Test public void lastIndexOfSparseStringArrayShouldNotBeNull() {
+        String[] strings = { null, "test" };
+        String result = testlib.ptr_return_array_element(strings, 1);
+        assertNotNull("last element of string array was null", result);
     }
 }


### PR DESCRIPTION
Fixes IndexOutOfBoundsException on copy of sparse `String[]`.  `CharSequenceArrayParameterConverter.StringArray` doesn't append nulls to the list, so if a null element in the source array is followed by a non-null element, IndexOutOfBoundsException is raised by `ArrayList#add`. The problem is fixed by appending nulls to `stringArray`.