### PR TITLE
Custom Union

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -137,7 +137,7 @@ public abstract class Struct {
      *
      * @param isUnion if this Struct is a Union
      */
-    Struct(Runtime runtime, final boolean isUnion) {
+    protected Struct(Runtime runtime, final boolean isUnion) {
         this(runtime);
         __info.resetIndex = isUnion;
         __info.isUnion = isUnion;


### PR DESCRIPTION
I've created a custom abstract struct class, that has some custom typedefs for my project. Now I can't use these typedefs in a Union, because Union is a direct subclass of jnr Struct, not my custom struct.

Protected constructor is best solution for me.