### PR TITLE
Start nested thread in the Finalizer.  Fixes #117

### DIFF
--- a/src/main/java/jnr/ffi/util/ref/internal/Finalizer.java
+++ b/src/main/java/jnr/ffi/util/ref/internal/Finalizer.java
@@ -163,6 +163,7 @@ public class Finalizer implements Runnable {
         // Set the context class loader to null in order to avoid
         // keeping a strong reference to an application classloader.
         thread.setContextClassLoader(null);
+        thread.start();
     }
 
     /**


### PR DESCRIPTION
The changes in 601bec2 converted the Finalizer from a Thread to a
Runnable which holds an internal reference to a new Thread.  This change
caused the run() method on the Finalizer to no longer be invoked,
leading to the cleanUp() it had been doing previously not being done
anymore.  In this commit, start() is called on the internal Thread.
This enables the Finalizer.run() method to be called on the new Thread,
where the cleanUp() would now start happening again.