### PR TITLE
[promotion]Link to spring-jnr

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ In addition, the following java types are mapped to a C pointer
 * Pointer - equivalent to "void *"
 * Buffer - equivalent to "void *"
 
+Useful tools
+------
+[spring-jnr](https://github.com/goto1134/spring-jnr) - Spring extension to load native libraries via jnr-ffi.


### PR DESCRIPTION
Adds link to [spring-jnr](https://github.com/goto1134/spring-jnr)- a Spring extension to load native libraries via jnr-ffi.