### PR TITLE
Fix snprintf function name in MSVCRT

### DIFF
--- a/src/test/java/jnr/ffi/VarargsTest.java
+++ b/src/test/java/jnr/ffi/VarargsTest.java
@@ -23,6 +23,10 @@ public class VarargsTest {
     @BeforeClass
     public static void setUpClass() throws Exception {
         LibraryLoader<C> loader = FFIProvider.getSystemProvider().createLibraryLoader(C.class);
+        if(Platform.getNativePlatform().getOS() == Platform.OS.WINDOWS)
+        {
+            loader.map("snprintf","_snprintf");
+        }
         c = loader.load(Platform.getNativePlatform().getStandardCLibraryName());
     }
 


### PR DESCRIPTION
`snprintf` function on Windows OS is called `_snprintf`. If the name is different,
UnsatisfiedLinkError is thrown.