### PR TITLE
WIP: ignore default methods

### DIFF
--- a/src/test/java/jnr/ffi/provider/InterfaceScannerTest.java
+++ b/src/test/java/jnr/ffi/provider/InterfaceScannerTest.java
@@ -14,7 +14,7 @@ public class InterfaceScannerTest {
     static {
         Method s = null;
         try {
-            Collection.class.getMethod("spliterator");
+            s = Collection.class.getMethod("spliterator");
         } catch (Exception e) {
             // leave null, tests will be skipped
         }


### PR DESCRIPTION
Implements ignore default methods in java 8.

it appers that #66 was not fixed and the test was always ignored.