### PR TITLE
Added from termios.h TypeAlias.cc_t, .speed_t and tcflag_t

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -2577,6 +2577,21 @@ public abstract class Struct {
         public time_t(Offset offset) { super(TypeAlias.time_t, offset); }
     }
 
+    public final class cc_t extends IntegerAlias {
+        public cc_t() { super(TypeAlias.cc_t); }
+        public cc_t(Offset offset) { super(TypeAlias.cc_t, offset); }
+    }
+
+    public final class speed_t extends IntegerAlias {
+        public speed_t() { super(TypeAlias.speed_t); }
+        public speed_t(Offset offset) { super(TypeAlias.speed_t, offset); }
+    }
+
+    public final class tcflag_t extends IntegerAlias {
+        public tcflag_t() { super(TypeAlias.tcflag_t); }
+        public tcflag_t(Offset offset) { super(TypeAlias.tcflag_t, offset); }
+    }
+
     public final class fsblkcnt_t extends IntegerAlias {
         public fsblkcnt_t() { super(TypeAlias.fsblkcnt_t); }
         public fsblkcnt_t(Offset offset) { super(TypeAlias.fsblkcnt_t, offset); }

--- a/src/main/java/jnr/ffi/TypeAlias.java
+++ b/src/main/java/jnr/ffi/TypeAlias.java
@@ -55,4 +55,7 @@ public enum TypeAlias {
     sa_family_t,
     socklen_t,
     rlim_t,
+    cc_t,
+    speed_t,
+    tcflag_t,
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/aarch64/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/aarch64/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/arm/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/arm/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/i386/darwin/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/i386/darwin/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/i386/freebsd/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/i386/freebsd/TypeAliases.java
@@ -62,6 +62,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.SLONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/i386/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/i386/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/i386/openbsd/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/i386/openbsd/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/i386/solaris/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/i386/solaris/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/i386/windows/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/i386/windows/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.SINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/mips/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/mips/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/mipsel/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/mipsel/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc/aix/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc/aix/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.ULONG);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc/darwin/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc/darwin/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc64/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc64/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc64le/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc64le/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/s390/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/s390/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/s390x/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/s390x/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/sparc/solaris/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/sparc/solaris/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/sparcv9/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/sparcv9/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/sparcv9/solaris/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/sparcv9/solaris/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/darwin/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/darwin/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/freebsd/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/freebsd/TypeAliases.java
@@ -62,6 +62,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/linux/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/openbsd/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/openbsd/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/solaris/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/solaris/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/windows/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/windows/TypeAliases.java
@@ -64,6 +64,9 @@ public final class TypeAliases {
         m.put(TypeAlias.sa_family_t, NativeType.USHORT);
         m.put(TypeAlias.socklen_t, NativeType.SINT);
         m.put(TypeAlias.rlim_t, NativeType.SINT);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
         return m;
     }
 }


### PR DESCRIPTION
These are needed typedefs for the termios structure.
For Linux the values are working - for the others I don't know If I got it right.