### PR TITLE
Load callback classes from their own ClassLoader (fixes #161)

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
@@ -126,7 +126,7 @@ public class AsmLibraryLoader extends LibraryLoader {
                 new CachingTypeMapper(new AnnotationTypeMapper()));
         
         typeMapper = new CompositeTypeMapper(typeMapper, 
-                new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, closureTypeMapper, classLoader), classLoader, NativeLibraryLoader.ASM_ENABLED)),
+                new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, closureTypeMapper), classLoader, NativeLibraryLoader.ASM_ENABLED)),
                 new CachingTypeMapper(new AnnotationTypeMapper()));
         
         CallingConvention libraryCallingConvention = getCallingConvention(interfaceClass, libraryOptions);

--- a/src/main/java/jnr/ffi/provider/jffi/NativeRuntime.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeRuntime.java
@@ -41,16 +41,7 @@ import java.util.logging.Logger;
 public final class NativeRuntime extends AbstractRuntime {
     private final NativeMemoryManager mm = new NativeMemoryManager(this);
     private final NativeClosureManager closureManager = new NativeClosureManager(this,
-            new SignatureTypeMapperAdapter(new DefaultTypeMapper()),
-            new AsmClassLoader(getParentClassLoader()));
-
-    private static ClassLoader getParentClassLoader() {
-        ClassLoader cl = NativeRuntime.class.getClassLoader();
-        if (cl == null) {
-            cl = ClassLoader.getSystemClassLoader();
-        }
-        return cl;
-    }
+            new SignatureTypeMapperAdapter(new DefaultTypeMapper()));
 
     private final Type[] aliases;
 

--- a/src/main/java/jnr/ffi/provider/jffi/ReflectionLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/ReflectionLibraryLoader.java
@@ -123,7 +123,7 @@ class ReflectionLibraryLoader extends LibraryLoader {
             }
 
             this.typeMapper = new CompositeTypeMapper(typeMapper,
-                    new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, typeMapper, classLoader), classLoader, NativeLibraryLoader.ASM_ENABLED)));
+                    new CachingTypeMapper(new InvokerTypeMapper(new NativeClosureManager(runtime, typeMapper), classLoader, NativeLibraryLoader.ASM_ENABLED)));
             libraryCallingConvention = getCallingConvention(interfaceClass, libraryOptions);
             libraryIsSynchronized = interfaceClass.isAnnotationPresent(Synchronized.class);
             invokerFactory = new DefaultInvokerFactory(runtime, library, this.typeMapper, functionMapper, libraryCallingConvention, libraryOptions, libraryIsSynchronized);


### PR DESCRIPTION
As a side effect, `NativeClosureManager` is now not tightly bound to a single `AsmClassLoader`, but it can work with any number of them.