### PR TITLE
Define tcflag_t and speed_t correctly on OS X

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/darwin/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/darwin/TypeAliases.java
@@ -65,8 +65,8 @@ public final class TypeAliases {
         m.put(TypeAlias.socklen_t, NativeType.UINT);
         m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
         m.put(TypeAlias.cc_t, NativeType.UCHAR);
-        m.put(TypeAlias.speed_t, NativeType.UINT);
-        m.put(TypeAlias.tcflag_t, NativeType.UINT);
+        m.put(TypeAlias.speed_t, NativeType.ULONG);
+        m.put(TypeAlias.tcflag_t, NativeType.ULONG);
         return m;
     }
 }


### PR DESCRIPTION
This fixes https://github.com/jnr/jnr-ffi/issues/174.