### PR TITLE
in Struct#toString(), catch and handle NullPointerException and IllegalAccessException

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -223,7 +223,13 @@ public abstract class Struct {
             try {
                 sb.append(fieldPrefix);
                 sb.append(field.getName()).append(" = ");
-                sb.append(field.get(this).toString());
+                try {
+                    sb.append(field.get(this).toString());
+                } catch (NullPointerException ex) {
+                    sb.append("- null -");
+                } catch (IllegalAccessException ex) {
+                    sb.append("- IllegalAccessException -");
+                }
                 sb.append("\n");
             } catch (Throwable ex) {
                 throw new RuntimeException(ex);


### PR DESCRIPTION
In Struct#toString(), catch and handle NullPointerException and IllegalAccessException so toString does not fail for private or null value fields:

If you call toString e.g. for a ru.serce.jnrfuse.struct.FileStat (see https://github.com/SerCeMan/jnr-fuse), you get an Exception instead of a human-readable String :(

To reproduce all cases covered by the PR, try out this:

    package jnr;
    
    import jnr.ffi.Runtime;
    import jnr.ffi.Struct;
    
    public class Demo extends Struct {
        public static void main(java.lang.String[] args) {
            System.out.println(new Demo(Runtime.getSystemRuntime()).toString());
        }
    
        private Demo(Runtime runtime) {
            super(runtime);
        }
        public final dev_t st_dev = new dev_t();            /* Device.  */
        private final Unsigned16 pad1 = new Unsigned16();   // IllegalAccessException in .toString()
        final Unsigned16 pad2 = new Unsigned16();           // IllegalAccessException in .toString()
        public final Unsigned16 pad3 = null;                // NullPointerException in .toString()
        public final Unsigned16 pad4 = new Unsigned16();    // works alright
        public final NumberField st_ino = new u_int64_t();  /* File serial number.	*/
    }
