### PR TITLE
Changed subclasses of AbstractNumberReference to avoid unnessesary cr…

### DIFF
--- a/src/main/java/jnr/ffi/byref/AbstractNumberReference.java
+++ b/src/main/java/jnr/ffi/byref/AbstractNumberReference.java
@@ -22,13 +22,11 @@ package jnr.ffi.byref;
  * An abstract class for common PrimitiveReference functionality
  */
 abstract public class AbstractNumberReference<T extends Number> extends Number implements ByReference<T> {
-    T value;
     
-    protected AbstractNumberReference(T value) {
-        this.value = value;
+    protected AbstractNumberReference() {
     }
-
-    protected static <T extends Number> T checkNull(T value) {
+    
+    protected <T extends Number> T checkNull(T value) {
         if (value == null) {
             throw new NullPointerException("reference value cannot be null");
         }
@@ -36,41 +34,13 @@ abstract public class AbstractNumberReference<T extends Number> extends Number i
         return value;
     }
 
+
+
     /**
-     * Gets the current value the reference points to.
+     * Gets the current  value wrapped up. the reference points to.
      *
      * @return the current value.
      */
-    public T getValue() {
-        return value;
-    }
+    abstract public T getValue();
     
-    @Override
-    public final byte byteValue() {
-        return value.byteValue();
-    }
-    
-    @Override
-    public final short shortValue() {
-        return value.byteValue();
-    }
-
-    public final int intValue() {
-        return value.intValue();
-    }
-
-    @Override
-    public final long longValue() {
-        return value.longValue();
-    }
-
-    @Override
-    public final float floatValue() {
-        return value.floatValue();
-    }
-
-    @Override
-    public final double doubleValue() {
-        return value.doubleValue();
-    }
 }

--- a/src/main/java/jnr/ffi/byref/ByteByReference.java
+++ b/src/main/java/jnr/ffi/byref/ByteByReference.java
@@ -59,11 +59,12 @@ import jnr.ffi.Runtime;
  */
 public final class ByteByReference extends AbstractNumberReference<Byte> {
 
+    private byte value;
+    
     /**
      * Creates a new reference to a byte value initialized to zero.
      */
     public ByteByReference() {
-        super(Byte.valueOf((byte) 0));
     }
 
     /**
@@ -71,19 +72,12 @@ public final class ByteByReference extends AbstractNumberReference<Byte> {
      * 
      * @param value the initial native value
      */
-    public ByteByReference(Byte value) {
-        super(checkNull(value));
+    public ByteByReference(byte value) {
+        super();
+        this.value = value;
     }
 
-    /**
-     * Creates a new reference to a byte value
-     *
-     * @param value the initial native value
-     */
-    public ByteByReference(byte value) {
-        super(value);
-    }
-    
+
     /**
      * Copies the Byte value to native memory
      *
@@ -112,4 +106,40 @@ public final class ByteByReference extends AbstractNumberReference<Byte> {
     public final int nativeSize(Runtime runtime) {
         return 1;
     }
+    
+    @Override
+    public Byte getValue() {
+        return Byte.valueOf(value);
+    }
+   
+    @Override
+    public byte byteValue() {
+        return value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short)value;
+    }
+
+    @Override
+    public int intValue() {
+        return (int)value;
+    }
+
+    @Override
+    public long longValue() {
+        return (long)value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float)value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double)value;
+    }
+    
 }

--- a/src/main/java/jnr/ffi/byref/DoubleByReference.java
+++ b/src/main/java/jnr/ffi/byref/DoubleByReference.java
@@ -25,31 +25,23 @@ import jnr.ffi.Runtime;
  *
  */
 public final class DoubleByReference extends AbstractNumberReference<Double> {
-    private static final Double DEFAULT = Double.valueOf(0d);
 
+    private double value;    
     /**
      * Creates a new reference to a double value initialized to zero.
      */
     public DoubleByReference() {
-        super(DEFAULT);
     }
 
-    /**
-     * Creates a new reference to a double value
-     * 
-     * @param value the initial native value
-     */
-    public DoubleByReference(Double value) {
-        super(checkNull(value));
-    }
-
+ 
     /**
      * Creates a new reference to a double value
      *
      * @param value the initial native value
      */
     public DoubleByReference(double value) {
-        super(value);
+        super();
+        this.value = value;
     }
     
     /**
@@ -82,5 +74,40 @@ public final class DoubleByReference extends AbstractNumberReference<Double> {
      */
     public final int nativeSize(Runtime runtime) {
         return 8;
+    }
+    
+    @Override
+    public Double getValue() {
+        return Double.valueOf(value);
+    }
+    
+     @Override
+    public byte byteValue() {
+        return (byte)value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short)value;
+    }
+
+    @Override
+    public int intValue() {
+        return (int)value;
+    }
+
+    @Override
+    public long longValue() {
+        return (long)value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float)value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return value;
     }
 }

--- a/src/main/java/jnr/ffi/byref/FloatByReference.java
+++ b/src/main/java/jnr/ffi/byref/FloatByReference.java
@@ -26,22 +26,12 @@ import jnr.ffi.Runtime;
  *
  */
 public final class FloatByReference extends AbstractNumberReference<Float> {
-    private static final Float DEFAULT = Float.valueOf(0f);
 
+    private float value;
     /**
      * Creates a new reference to a short value initialized to zero.
      */
     public FloatByReference() {
-        super(DEFAULT);
-    }
-
-    /**
-     * Creates a new reference to a float value
-     * 
-     * @param value the initial native value
-     */
-    public FloatByReference(Float value) {
-        super(checkNull(value));
     }
 
     /**
@@ -50,7 +40,8 @@ public final class FloatByReference extends AbstractNumberReference<Float> {
      * @param value the initial native value
      */
     public FloatByReference(float value) {
-        super(value);
+        super();
+        this.value = value;
     }
     
     /**
@@ -83,5 +74,40 @@ public final class FloatByReference extends AbstractNumberReference<Float> {
      */
     public final int nativeSize(Runtime runtime) {
         return 4;
+    }
+    
+    @Override
+    public Float getValue() {
+        return Float.valueOf(value);
+    }
+    
+    @Override
+    public byte byteValue() {
+        return (byte)value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short)value;
+    }
+
+    @Override
+    public int intValue() {
+        return (int)value;
+    }
+
+    @Override
+    public long longValue() {
+        return (long)value;
+    }
+
+    @Override
+    public float floatValue() {
+        return value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double)value;
     }
 }

--- a/src/main/java/jnr/ffi/byref/IntByReference.java
+++ b/src/main/java/jnr/ffi/byref/IntByReference.java
@@ -60,20 +60,11 @@ import jnr.ffi.Runtime;
  */
 public final class IntByReference extends AbstractNumberReference<Integer> {
 
+    private int value;
     /**
      * Creates a new reference to an integer value initialized to zero.
      */
     public IntByReference() {
-        super(Integer.valueOf(0));
-    }
-
-    /**
-     * Creates a new reference to an integer value
-     * 
-     * @param value the initial native value
-     */
-    public IntByReference(Integer value) {
-        super(checkNull(value));
     }
 
     /**
@@ -82,7 +73,8 @@ public final class IntByReference extends AbstractNumberReference<Integer> {
      * @param value the initial native value
      */
     public IntByReference(int value) {
-        super(value);
+        super();
+        this.value = value;
     }
     
     /**
@@ -114,5 +106,40 @@ public final class IntByReference extends AbstractNumberReference<Integer> {
      */
     public int nativeSize(Runtime runtime) {
         return 4;
+    }
+    
+    @Override
+    public Integer getValue() {
+        return Integer.valueOf(value);
+    }
+    
+    @Override
+    public byte byteValue() {
+        return (byte)value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short)value;
+    }
+
+    @Override
+    public int intValue() {
+        return value;
+    }
+
+    @Override
+    public long longValue() {
+        return (long)value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float)value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double)value;
     }
 }

--- a/src/main/java/jnr/ffi/byref/LongLongByReference.java
+++ b/src/main/java/jnr/ffi/byref/LongLongByReference.java
@@ -60,29 +60,22 @@ import jnr.ffi.Runtime;
  */
 public final class LongLongByReference extends AbstractNumberReference<Long> {
     
+    private long value;
+    
     /**
      * Creates a new reference to a long long value initialized to zero.
      */
     public LongLongByReference() {
-        super(Long.valueOf(0));
     }
     
-    /**
-     * Creates a new reference to a native longlong value
-     * 
-     * @param value the initial native value
-     */
-    public LongLongByReference(Long value) {
-        super(checkNull(value));
-    }
-
     /**
      * Creates a new reference to a native longlong value
      *
      * @param value the initial native value
      */
     public LongLongByReference(long value) {
-        super(value);
+        super();
+        this.value = value;
     }
     
     /**
@@ -115,5 +108,40 @@ public final class LongLongByReference extends AbstractNumberReference<Long> {
      */
     public final int nativeSize(Runtime runtime) {
         return 8;
+    }
+    
+    @Override
+    public Long getValue() {
+        return Long.valueOf(value);
+    }
+    
+    @Override
+    public byte byteValue() {
+        return (byte)value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short)value;
+    }
+
+    @Override
+    public int intValue() {
+        return (int)value;
+    }
+
+    @Override
+    public long longValue() {
+        return value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float)value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double)value;
     }
 }

--- a/src/main/java/jnr/ffi/byref/NativeLongByReference.java
+++ b/src/main/java/jnr/ffi/byref/NativeLongByReference.java
@@ -60,29 +60,22 @@ import jnr.ffi.Runtime;
  */
 public final class NativeLongByReference extends AbstractNumberReference<NativeLong> {
     
+    private long value; 
+    
     /**
      * Creates a new reference to a native long value initialized to zero.
      */
     public NativeLongByReference() {
-        super(NativeLong.valueOf(0));
     }
     
-    /**
-     * Creates a new reference to a native long value
-     * 
-     * @param value the initial native value
-     */
-    public NativeLongByReference(NativeLong value) {
-        super(checkNull(value));
-    }
-
     /**
      * Creates a new reference to a native long value
      *
      * @param value the initial native value
      */
     public NativeLongByReference(long value) {
-        super(NativeLong.valueOf(value));
+        super();
+        this.value = value;
     }
     
     /**
@@ -93,7 +86,7 @@ public final class NativeLongByReference extends AbstractNumberReference<NativeL
      * @param offset  the memory offset.
      */
     public void toNative(Runtime runtime, Pointer memory, long offset) {
-        memory.putNativeLong(offset, value.longValue());
+        memory.putNativeLong(offset, value);
     }
 
     /**
@@ -104,7 +97,7 @@ public final class NativeLongByReference extends AbstractNumberReference<NativeL
      * @param offset  the memory offset.
      */
     public void fromNative(Runtime runtime, Pointer memory, long offset) {
-        this.value = NativeLong.valueOf(memory.getNativeLong(offset));
+        this.value = memory.getNativeLong(offset);
     }
     
     /**
@@ -116,4 +109,40 @@ public final class NativeLongByReference extends AbstractNumberReference<NativeL
     public final int nativeSize(Runtime runtime) {
         return runtime.longSize();
     }
+    
+    @Override
+    public NativeLong getValue() {
+        return NativeLong.valueOf(value);
+    }
+    
+    @Override
+    public byte byteValue() {
+        return (byte)value;
+    }
+
+    @Override
+    public short shortValue() {
+        return (short)value;
+    }
+
+    @Override
+    public int intValue() {
+        return (int)value;
+    }
+
+    @Override
+    public long longValue() {
+        return value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float)value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double)value;
+    }
+
 }

--- a/src/main/java/jnr/ffi/byref/NumberByReference.java
+++ b/src/main/java/jnr/ffi/byref/NumberByReference.java
@@ -65,14 +65,14 @@ import jnr.ffi.Runtime;
  */
 public class NumberByReference extends AbstractNumberReference<Number> {
     private final TypeAlias typeAlias;
+    private Number value; 
 
     public NumberByReference(TypeAlias typeAlias, Number value) {
-        super(checkNull(value));
-        this.typeAlias = typeAlias;
-    }
-
-    public NumberByReference(TypeAlias typeAlias) {
-        super(0);
+        super();
+        if (value == null) {
+            throw new NullPointerException("reference value cannot be null");
+        }
+        this.value = value;
         this.typeAlias = typeAlias;
     }
 
@@ -170,4 +170,40 @@ public class NumberByReference extends AbstractNumberReference<Number> {
                 throw new UnsupportedOperationException("unsupported type: " + typeAlias);
         }
     }
+    
+    @Override
+    public Number getValue() {
+        return value;
+    }
+    
+    @Override
+    public byte byteValue() {
+        return value.byteValue();
+    }
+
+    @Override
+    public short shortValue() {
+        return value.shortValue();
+    }
+
+    @Override
+    public int intValue() {
+        return value.intValue();
+    }
+
+    @Override
+    public long longValue() {
+        return value.longValue();
+    }
+
+    @Override
+    public float floatValue() {
+        return value.floatValue();
+    }
+
+    @Override
+    public double doubleValue() {
+        return value.doubleValue();
+    }
+
 }

--- a/src/main/java/jnr/ffi/byref/ShortByReference.java
+++ b/src/main/java/jnr/ffi/byref/ShortByReference.java
@@ -59,20 +59,12 @@ import jnr.ffi.Runtime;
  */
 public final class ShortByReference extends AbstractNumberReference<Short> {
     
+    private short value;
     /**
      * Creates a new reference to a short value initialized to zero.
      */
     public ShortByReference() {
-        super(Short.valueOf((short) 0));
-    }
-
-    /**
-     * Creates a new reference to a short value.
-     * 
-     * @param value the initial native value
-     */
-    public ShortByReference(Short value) {
-        super(checkNull(value));
+        super();
     }
 
     /**
@@ -81,7 +73,8 @@ public final class ShortByReference extends AbstractNumberReference<Short> {
      * @param value the initial native value
      */
     public ShortByReference(short value) {
-        super(value);
+        super();
+        this.value = value;
     }
     
     /**
@@ -115,4 +108,40 @@ public final class ShortByReference extends AbstractNumberReference<Short> {
     public final int nativeSize(Runtime runtime) {
         return 2;
     }
+    
+    @Override
+    public Short getValue() {
+        return Short.valueOf(value);
+    }
+    
+    @Override
+    public byte byteValue() {
+        return (byte)value;
+    }
+
+    @Override
+    public short shortValue() {
+        return value;
+    }
+
+    @Override
+    public int intValue() {
+        return (int)value;
+    }
+
+    @Override
+    public long longValue() {
+        return (long)value;
+    }
+
+    @Override
+    public float floatValue() {
+        return (float)value;
+    }
+
+    @Override
+    public double doubleValue() {
+        return (double)value;
+    }
+
 }


### PR DESCRIPTION
I "cleand up" the subclasses of AbstractNumberReference to avoid to create instances of Number twice.
It uses the plain types byte,short,int,long,float and long and all wrapper methods like byteValue() are "taken" from i.E. Byte.byteValue(), Short.byteValue() ...
 
So it should be faster.

One point remains should the filed value be public so it can be set also?