### PR TITLE
Initial support for DragonFly BSD

### DIFF
--- a/libtest/NumberTest.c
+++ b/libtest/NumberTest.c
@@ -21,7 +21,7 @@
 # include <stdint.h>
 #endif
 
-#if !defined(_STDINT_H) && !defined(_SYS__STDINT_H_)
+#if !defined (_STDINT_H_) && !defined(_STDINT_H) && !defined(_SYS__STDINT_H_)
 typedef signed char int8_t;
 typedef signed short int16_t;
 typedef signed int int32_t;

--- a/libtest/PointerTest.c
+++ b/libtest/PointerTest.c
@@ -29,7 +29,7 @@ typedef void* pointer;
 #ifdef _WIN32
 typedef char* caddr_t;
 #endif
-#if !defined(_STDINT_H) && !defined(_SYS__STDINT_H_)
+#if !defined(_STDINT_H_) && !defined(_STDINT_H) && !defined(_SYS__STDINT_H_)
 typedef signed char int8_t;
 typedef signed short int16_t;
 typedef signed int int32_t;

--- a/libtest/ReferenceTest.c
+++ b/libtest/ReferenceTest.c
@@ -20,7 +20,7 @@
 # include <stdint.h>
 #endif
 
-#if !defined(_STDINT_H) && !defined(_SYS__STDINT_H_)
+#if !defined(_STDINT_H_) && !defined(_STDINT_H) && !defined(_SYS__STDINT_H_)
 typedef signed char int8_t;
 typedef signed short int16_t;
 typedef signed int int32_t;

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,30 @@
   </build>
   <profiles>
     <profile>
+      <id>linux-profile</id>
+      <activation>
+        <os><name>linux</name></os>
+      </activation>
+    </profile>
+    <profile>
+      <id>freebsd-profile</id>
+      <activation>
+        <os><name>freebsd</name></os>
+      </activation>
+      <properties>
+        <make>gmake</make>
+      </properties>
+    </profile>
+    <profile>
+      <id>dragonfly-profile</id>
+      <activation>
+        <os><name>dragonflybsd</name></os>
+      </activation>
+      <properties>
+        <make>gmake</make>
+      </properties>
+    </profile>
+    <profile>
       <id>release-sign-artifacts</id>
       <activation>
         <property>

--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -55,6 +55,8 @@ public abstract class Platform {
         NETBSD,
         /** OpenBSD */
         OPENBSD,
+	/** DragonFly */
+	DRAGONFLY,
         /** Linux */
         LINUX,
         /** Solaris (and OpenSolaris) */
@@ -152,6 +154,8 @@ public abstract class Platform {
             return OS.OPENBSD;
         } else if (startsWithIgnoreCase(osName, "freebsd")) {
             return OS.FREEBSD;
+        } else if (startsWithIgnoreCase(osName, "dragonfly")) {
+            return OS.DRAGONFLY;
         } else if (startsWithIgnoreCase(osName, "windows")) {
             return OS.WINDOWS;
         } else {
@@ -316,7 +320,7 @@ public abstract class Platform {
     }
     
     public final boolean isBSD() {
-        return os == OS.FREEBSD || os == OS.OPENBSD || os == OS.NETBSD || os == OS.DARWIN;
+        return os == OS.FREEBSD || os == OS.OPENBSD || os == OS.NETBSD || os == OS.DARWIN || os == OS.DRAGONFLY;
     }
     public final boolean isUnix() {
         return os != OS.WINDOWS;
@@ -362,6 +366,7 @@ public abstract class Platform {
             return "libc.so.6";
         case SOLARIS:
             return "c";
+        case DRAGONFLY:
         case FREEBSD:
         case NETBSD:
             return "c";

--- a/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/dragonfly/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/x86_64/dragonfly/TypeAliases.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2012 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.ffi.provider.jffi.platform.x86_64.dragonfly;
+import jnr.ffi.TypeAlias;
+import jnr.ffi.NativeType;
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class TypeAliases {
+    public static final Map<TypeAlias, jnr.ffi.NativeType> ALIASES = buildTypeMap();
+    private static Map<TypeAlias, jnr.ffi.NativeType> buildTypeMap() {
+        Map<TypeAlias, jnr.ffi.NativeType> m = new EnumMap<TypeAlias, jnr.ffi.NativeType>(TypeAlias.class);
+        m.put(TypeAlias.int8_t, NativeType.SCHAR);
+        m.put(TypeAlias.u_int8_t, NativeType.UCHAR);
+        m.put(TypeAlias.int16_t, NativeType.SSHORT);
+        m.put(TypeAlias.u_int16_t, NativeType.USHORT);
+        m.put(TypeAlias.int32_t, NativeType.SINT);
+        m.put(TypeAlias.u_int32_t, NativeType.UINT);
+        m.put(TypeAlias.int64_t, NativeType.SLONGLONG);
+        m.put(TypeAlias.u_int64_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.intptr_t, NativeType.SLONG);
+        m.put(TypeAlias.uintptr_t, NativeType.ULONG);
+        m.put(TypeAlias.caddr_t, NativeType.ADDRESS);
+        m.put(TypeAlias.dev_t, NativeType.SINT);
+        m.put(TypeAlias.blkcnt_t, NativeType.SLONG);
+        m.put(TypeAlias.blksize_t, NativeType.SLONG);
+        m.put(TypeAlias.gid_t, NativeType.UINT);
+        m.put(TypeAlias.in_addr_t, NativeType.UINT);
+        m.put(TypeAlias.in_port_t, NativeType.USHORT);
+        m.put(TypeAlias.ino_t, NativeType.UINT);
+        m.put(TypeAlias.ino64_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.key_t, NativeType.SLONG);
+        m.put(TypeAlias.mode_t, NativeType.UINT);
+        m.put(TypeAlias.nlink_t, NativeType.UINT);
+        m.put(TypeAlias.id_t, NativeType.UINT);
+        m.put(TypeAlias.pid_t, NativeType.SINT);
+        m.put(TypeAlias.off_t, NativeType.SLONGLONG);
+        m.put(TypeAlias.swblk_t, NativeType.SINT);
+        m.put(TypeAlias.uid_t, NativeType.UINT);
+        m.put(TypeAlias.clock_t, NativeType.SINT);
+        m.put(TypeAlias.size_t, NativeType.ULONG);
+        m.put(TypeAlias.ssize_t, NativeType.SLONG);
+        m.put(TypeAlias.time_t, NativeType.SINT);
+        m.put(TypeAlias.fsblkcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.fsfilcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
+        m.put(TypeAlias.socklen_t, NativeType.UINT);
+        m.put(TypeAlias.rlim_t, NativeType.ULONGLONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
+        return m;
+    }
+}


### PR DESCRIPTION
This is initial support for DragonFly BSD, it might not be 100% correct at the moment but the tests are passed (see below).

This requires (https://github.com/jnr/jffi/pull/64) first or tests will fail.

    -------------------------------------------------------
     T E S T S
    -------------------------------------------------------
    Running jnr.ffi.NumberTest
    Tests run: 17, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.926 sec
    Running jnr.ffi.ResultConverterTest
    Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.045 sec
    Running jnr.ffi.EnumTest
    [...]
    Running jnr.ffi.PlatformTest
    Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.055 sec
    Running jnr.ffi.struct.PaddingTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec
    
    Results :
    
    Tests run: 289, Failures: 0, Errors: 0, Skipped: 0
