### PR TITLE
Add TypeAliases for aix ppc64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <version>7</version>
   </parent>
 
-  <groupId>com.github.Johan-Lecuyer</groupId>
+  <groupId>com.github.jnr</groupId>
   <artifactId>jnr-ffi</artifactId>
   <packaging>jar</packaging>
   <version>2.1.10-SNAPSHOT</version>
   <name>jnr-ffi</name>
   <description>A library for invoking native functions from java</description>
-  <url>http://github.com/Johan-Lecuyer/jnr-ffi</url>
+  <url>http://github.com/jnr/jnr-ffi</url>
 
   <licenses>
     <license>
@@ -23,9 +23,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:Johan-Lecuyer/jnr-ffi.git</connection>
-    <developerConnection>scm:git:git@github.com:Johan-Lecuyer/jnr-ffi.git</developerConnection>
-    <url>git@github.com:Johan-Lecuyer/jnr-ffi.git</url>
+    <connection>scm:git:git@github.com:jnr/jnr-ffi.git</connection>
+    <developerConnection>scm:git:git@github.com:jnr/jnr-ffi.git</developerConnection>
+    <url>git@github.com:jnr/jnr-ffi.git</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <version>7</version>
   </parent>
 
-  <groupId>com.github.jnr</groupId>
+  <groupId>com.github.Johan-Lecuyer</groupId>
   <artifactId>jnr-ffi</artifactId>
   <packaging>jar</packaging>
   <version>2.1.10-SNAPSHOT</version>
   <name>jnr-ffi</name>
   <description>A library for invoking native functions from java</description>
-  <url>http://github.com/jnr/jnr-ffi</url>
+  <url>http://github.com/Johan-Lecuyer/jnr-ffi</url>
 
   <licenses>
     <license>
@@ -23,9 +23,9 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git@github.com:jnr/jnr-ffi.git</connection>
-    <developerConnection>scm:git:git@github.com:jnr/jnr-ffi.git</developerConnection>
-    <url>git@github.com:jnr/jnr-ffi.git</url>
+    <connection>scm:git:git@github.com:Johan-Lecuyer/jnr-ffi.git</connection>
+    <developerConnection>scm:git:git@github.com:Johan-Lecuyer/jnr-ffi.git</developerConnection>
+    <url>git@github.com:Johan-Lecuyer/jnr-ffi.git</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc64/aix/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc64/aix/TypeAliases.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package jnr.ffi.provider.jffi.platform.ppc.aix;
+package jnr.ffi.provider.jffi.platform.ppc64.aix;
 
 import jnr.ffi.NativeType;
 import jnr.ffi.TypeAlias;

--- a/src/main/java/jnr/ffi/provider/jffi/platform/ppc64/aix/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/ppc64/aix/TypeAliases.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2012 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.ffi.provider.jffi.platform.ppc.aix;
+
+import jnr.ffi.NativeType;
+import jnr.ffi.TypeAlias;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class TypeAliases {
+    public static final Map<TypeAlias, jnr.ffi.NativeType> ALIASES = buildTypeMap();
+    private static Map<TypeAlias, jnr.ffi.NativeType> buildTypeMap() {
+        Map<TypeAlias, jnr.ffi.NativeType> m = new EnumMap<TypeAlias, jnr.ffi.NativeType>(TypeAlias.class);
+        m.put(TypeAlias.int8_t, NativeType.SCHAR);
+        m.put(TypeAlias.u_int8_t, NativeType.UCHAR);
+        m.put(TypeAlias.int16_t, NativeType.SSHORT);
+        m.put(TypeAlias.u_int16_t, NativeType.USHORT);
+        m.put(TypeAlias.int32_t, NativeType.SINT);
+        m.put(TypeAlias.u_int32_t, NativeType.UINT);
+        m.put(TypeAlias.int64_t, NativeType.ADDRESS);
+        m.put(TypeAlias.u_int64_t, NativeType.ADDRESS);
+        m.put(TypeAlias.intptr_t, NativeType.SLONG);
+        m.put(TypeAlias.uintptr_t, NativeType.ULONG);
+        m.put(TypeAlias.caddr_t, NativeType.ADDRESS);
+        m.put(TypeAlias.dev_t, NativeType.ULONG);
+        m.put(TypeAlias.blkcnt_t, NativeType.SLONG);
+        m.put(TypeAlias.blksize_t, NativeType.SINT);
+        m.put(TypeAlias.gid_t, NativeType.UINT);
+        m.put(TypeAlias.in_addr_t, NativeType.UINT);
+        m.put(TypeAlias.in_port_t, NativeType.USHORT);
+        m.put(TypeAlias.ino_t, NativeType.UINT);
+        m.put(TypeAlias.ino64_t, NativeType.ULONG);
+        m.put(TypeAlias.key_t, NativeType.SINT);
+        m.put(TypeAlias.mode_t, NativeType.UINT);
+        m.put(TypeAlias.nlink_t, NativeType.SINT);
+        m.put(TypeAlias.id_t, NativeType.UINT);
+        m.put(TypeAlias.pid_t, NativeType.SINT);
+        m.put(TypeAlias.off_t, NativeType.SLONG);
+        m.put(TypeAlias.swblk_t, NativeType.SINT);
+        m.put(TypeAlias.uid_t, NativeType.UINT);
+        m.put(TypeAlias.clock_t, NativeType.SINT);
+        m.put(TypeAlias.size_t, NativeType.ULONG);
+        m.put(TypeAlias.ssize_t, NativeType.SLONG);
+        m.put(TypeAlias.time_t, NativeType.SINT);
+        m.put(TypeAlias.fsblkcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.fsfilcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.sa_family_t, NativeType.UCHAR);
+        m.put(TypeAlias.socklen_t, NativeType.ULONG);
+        m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
+        return m;
+    }
+}


### PR DESCRIPTION
jnr ffi not supported for aix ppc64 because typealiases is not defined. It'is a fixed bug