### PR TITLE
Add support for searching the "default" library

### DIFF
--- a/src/main/java/jnr/ffi/Library.java
+++ b/src/main/java/jnr/ffi/Library.java
@@ -111,20 +111,7 @@ public final class Library {
      */
     public static <T> T loadLibrary(Class<T> interfaceClass, Map<LibraryOption, ?> libraryOptions,
             String... libraryNames) {
-        LibraryLoader<T> loader = FFIProvider.getSystemProvider().createLibraryLoader(interfaceClass);
-
-        for (String libraryName : libraryNames) {
-            loader.library(libraryName);
-            for (String path : getLibraryPath(libraryName)) {
-                loader.search(path);
-            }
-        }
-
-        for (Map.Entry<LibraryOption, ?> option : libraryOptions.entrySet()) {
-            loader.option(option.getKey(), option.getValue());
-        }
-
-        return loader.failImmediately().load();
+        return LibraryLoader.loadLibrary(interfaceClass, libraryOptions, customSearchPaths, libraryNames);
     }
     
     /**

--- a/src/main/java/jnr/ffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/LibraryLoader.java
@@ -21,7 +21,6 @@ package jnr.ffi;
 import jnr.ffi.mapper.*;
 import jnr.ffi.provider.FFIProvider;
 import jnr.ffi.provider.LoadedLibrary;
-import jnr.ffi.provider.NativeInvocationHandler;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -51,6 +50,8 @@ import java.util.*;
  * </pre>
  */
 public abstract class LibraryLoader<T> {
+    public static final String DEFAULT_LIBRARY = "RTLD_DEFAULT";
+
     private final List<String> searchPaths = new ArrayList<String>();
     private final List<String> libraryNames = new ArrayList<String>();
     private final List<SignatureTypeMapper> typeMappers = new ArrayList<SignatureTypeMapper>();
@@ -113,6 +114,57 @@ public abstract class LibraryLoader<T> {
     }
 
     /**
+     * Loads a native library and links the methods defined in {@code interfaceClass}
+     * to native methods in the library.
+     *
+     * @param <T> the interface type.
+     * @param libraryNames the name of the library to load
+     * @param interfaceClass the interface that describes the native library interface
+     * @param searchPaths a map of library names to paths that should be searched
+     * @param libraryOptions options
+     * @return an instance of {@code interfaceclass} that will call the native methods.
+     */
+    public static <T> T loadLibrary(
+            Class<T> interfaceClass,
+            Map<LibraryOption, ?> libraryOptions,
+            Map<String, List<String>> searchPaths,
+            String... libraryNames) {
+        LibraryLoader<T> loader = FFIProvider.getSystemProvider().createLibraryLoader(interfaceClass);
+
+        for (String libraryName : libraryNames) {
+            if (libraryName.equals(LibraryLoader.DEFAULT_LIBRARY)) {
+                loader.searchDefault();
+                continue;
+            }
+
+            loader.library(libraryName);
+
+            List<String> paths = searchPaths.get(libraryName);
+            if (paths != null) for (String path : paths) {
+                loader.search(path);
+            }
+        }
+
+        for (Map.Entry<LibraryOption, ?> option : libraryOptions.entrySet()) {
+            loader.option(option.getKey(), option.getValue());
+        }
+
+        return loader.failImmediately().load();
+    }
+
+    /**
+     * Same as calling {@link #loadLibrary(Class, Map, Map, String...)} with an empty search path map.
+     *
+     * @see #loadLibrary(Class, Map, Map, String...)
+     */
+    public static <T> T loadLibrary(
+            Class<T> interfaceClass,
+            Map<LibraryOption, ?> libraryOptions,
+            String... libraryNames) {
+        return (T) loadLibrary(interfaceClass, libraryOptions, Collections.EMPTY_MAP, libraryNames);
+    }
+
+    /**
      * Adds a library to be loaded.  Multiple libraries can be specified using additional calls
      * to this method, and all libraries will be searched to resolve symbols (e.g. functions, variables).
      *
@@ -120,7 +172,22 @@ public abstract class LibraryLoader<T> {
      * @return The {@code LibraryLoader} instance.
      */
     public LibraryLoader<T> library(String libraryName) {
+        if (libraryName.equals(DEFAULT_LIBRARY)) {
+            return searchDefault();
+        }
+
         this.libraryNames.add(libraryName);
+        return this;
+    }
+
+    /**
+     * Add the default library to the search order. This will search all loaded libraries in the current process
+     * according to the system's implementation of dlsym(RTLD_DEFAULT).
+     *
+     * @return The {@code LibraryLoader} instance.
+     */
+    public LibraryLoader<T> searchDefault() {
+        this.libraryNames.add(DEFAULT_LIBRARY);
         return this;
     }
 

--- a/src/main/java/jnr/ffi/provider/jffi/NativeLibrary.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeLibrary.java
@@ -18,11 +18,12 @@
 
 package jnr.ffi.provider.jffi;
 
+import com.kenai.jffi.Library;
+import jnr.ffi.LibraryLoader;
 import jnr.ffi.Platform;
 
 import java.io.*;
 import java.util.*;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -74,8 +75,13 @@ public class NativeLibrary {
         List<com.kenai.jffi.Library> libs = new ArrayList<com.kenai.jffi.Library>();
         
         for (String libraryName : libraryNames) {
+            if (libraryName.equals(LibraryLoader.DEFAULT_LIBRARY)) {
+                libs.add(Library.getDefault());
+                continue;
+            }
+
             com.kenai.jffi.Library lib;
-            
+
             lib = openLibrary(libraryName);
             if (lib == null) {
                 String path;

--- a/src/test/java/jnr/ffi/LibraryLoaderTest.java
+++ b/src/test/java/jnr/ffi/LibraryLoaderTest.java
@@ -19,6 +19,7 @@
 package jnr.ffi;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertEquals;
 import jnr.ffi.mapper.FunctionMapper;
@@ -145,5 +146,32 @@ public class LibraryLoaderTest {
 
         double a = lib.subd(lib.addd(30.0, 20.0), 8.0);
         assertEquals(a, 42.0, 1e-4);
+    }
+
+    public interface DefaultGetpid {
+        long getpid();
+    }
+
+    @Test
+    public void searchDefault() {
+        // explicit default search
+        LibraryLoader<DefaultGetpid> loader = FFIProvider.getSystemProvider().createLibraryLoader(DefaultGetpid.class);
+
+        loader.searchDefault();
+
+        DefaultGetpid dgp = loader.load();
+
+        assertNotNull(dgp);
+        assertTrue(dgp.getpid() > 0);
+
+        // try with default name
+        loader = FFIProvider.getSystemProvider().createLibraryLoader(DefaultGetpid.class);
+
+        loader.library(LibraryLoader.DEFAULT_LIBRARY);
+
+        dgp = loader.load();
+
+        assertNotNull(dgp);
+        assertTrue(dgp.getpid() > 0);
     }
 }


### PR DESCRIPTION
The default search will not attempt to load any libraries, and
instead will search all images loaded into the current process
acording to dlsym(RTLD_DEFAULT). This is accomplished without using
the platform-specific RTLD_DEFAULT constant by using the default
library from jffi, which is acquired by executing dlopen with a
null path.

This commit also moves the all-at-once loadLibrary functionality
out of Library and into LibraryLoader, since it's useful for
bootstrapping a library without using the builder API.

Part of work for jruby/jruby#6202.

Fixes #203.