### PR TITLE
Add an allocateDirect path that accepts long

### DIFF
--- a/src/main/java/jnr/ffi/Memory.java
+++ b/src/main/java/jnr/ffi/Memory.java
@@ -96,6 +96,19 @@ public final class Memory {
      * accessor.
      *
      * @param runtime The current runtime.
+     * @param size The size in bytes of memory to allocate.
+     *
+     * @return a {@code Pointer} instance that can access the memory.
+     */
+    public static Pointer allocateDirect(Runtime runtime, long size) {
+        return runtime.getMemoryManager().allocateDirect(size);
+    }
+
+    /**
+     * Allocates a new block of native memory and wraps it in a {@link Pointer}
+     * accessor.
+     *
+     * @param runtime The current runtime.
      * @param type The native type to allocate memory for.
      *
      * @return a {@code Pointer} instance that can access the memory.
@@ -129,6 +142,21 @@ public final class Memory {
      * @return a {@code Pointer} instance that can access the memory.
      */
     public static Pointer allocateDirect(Runtime runtime, int size, boolean clear) {
+        return runtime.getMemoryManager().allocateDirect(size, clear);
+    }
+
+    /**
+     * Allocates a new block of native memory and wraps it in a {@link Pointer}
+     * accessor.
+     *
+     * @param runtime The current runtime.
+     * @param size The size in bytes of memory to allocate.
+     * @param clear Whether the memory contents should be cleared, or left as
+     * random data.
+     *
+     * @return a {@code Pointer} instance that can access the memory.
+     */
+    public static Pointer allocateDirect(Runtime runtime, long size, boolean clear) {
         return runtime.getMemoryManager().allocateDirect(size, clear);
     }
 

--- a/src/main/java/jnr/ffi/provider/MemoryManager.java
+++ b/src/main/java/jnr/ffi/provider/MemoryManager.java
@@ -28,7 +28,9 @@ import java.nio.ByteBuffer;
 public interface MemoryManager {
     public abstract Pointer allocate(int size);
     public abstract Pointer allocateDirect(int size);
+    public abstract Pointer allocateDirect(long size);
     public abstract Pointer allocateDirect(int size, boolean clear);
+    public abstract Pointer allocateDirect(long size, boolean clear);
     public abstract Pointer allocateTemporary(int size, boolean clear);
     public abstract Pointer newPointer(ByteBuffer buffer);
     public abstract Pointer newPointer(long address);

--- a/src/main/java/jnr/ffi/provider/jffi/AllocatedDirectMemoryIO.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AllocatedDirectMemoryIO.java
@@ -24,9 +24,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 class AllocatedDirectMemoryIO extends DirectMemoryIO {
     private final AtomicBoolean allocated = new AtomicBoolean(true);
-    private final int size;
+    private final long size;
     
-    public AllocatedDirectMemoryIO(Runtime runtime, int size, boolean clear) {
+    public AllocatedDirectMemoryIO(Runtime runtime, long size, boolean clear) {
         super(runtime, IO.allocateMemory(size, clear));
         this.size = size;
         if (address() == 0L) {

--- a/src/main/java/jnr/ffi/provider/jffi/NativeMemoryManager.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeMemoryManager.java
@@ -41,7 +41,15 @@ public class NativeMemoryManager implements jnr.ffi.provider.MemoryManager {
         return new BoundedMemoryIO(TransientNativeMemory.allocate(runtime, size, 8, true), 0, size);
     }
 
+    public Pointer allocateDirect(long size) {
+        return new BoundedMemoryIO(TransientNativeMemory.allocate(runtime, size, 8, true), 0, size);
+    }
+
     public Pointer allocateDirect(int size, boolean clear) {
+        return new BoundedMemoryIO(TransientNativeMemory.allocate(runtime, size, 8, clear), 0, size);
+    }
+
+    public Pointer allocateDirect(long size, boolean clear) {
         return new BoundedMemoryIO(TransientNativeMemory.allocate(runtime, size, 8, clear), 0, size);
     }
 

--- a/src/main/java/jnr/ffi/provider/jffi/TransientNativeMemory.java
+++ b/src/main/java/jnr/ffi/provider/jffi/TransientNativeMemory.java
@@ -39,9 +39,13 @@ public class TransientNativeMemory extends DirectMemoryIO {
     private static final int PAGES_PER_MAGAZINE = 2;
 
     private final Sentinel sentinel;
-    private final int size;
-    
+    private final long size;
+
     public static DirectMemoryIO allocate(jnr.ffi.Runtime runtime, int size, int align, boolean clear) {
+        return allocate(runtime, (long) size, align, clear);
+    }
+    
+    public static DirectMemoryIO allocate(jnr.ffi.Runtime runtime, long size, int align, boolean clear) {
         if (size < 0) {
             throw new IllegalArgumentException("negative size: " + size);
         }
@@ -77,7 +81,7 @@ public class TransientNativeMemory extends DirectMemoryIO {
     }
 
 
-    TransientNativeMemory(jnr.ffi.Runtime runtime, Sentinel sentinel, long address, int size) {
+    TransientNativeMemory(jnr.ffi.Runtime runtime, Sentinel sentinel, long address, long size) {
         super(runtime, address);
         this.sentinel = sentinel;
         this.size = size;
@@ -137,7 +141,7 @@ public class TransientNativeMemory extends DirectMemoryIO {
             return sentinelReference.get();
         }
 
-        long allocate(int size, int align) {
+        long allocate(long size, int align) {
             long address = align(this.memory, align);
             if (address + size <= end) {
                 memory = address + size;


### PR DESCRIPTION
This allows allocating native memory sizes larger than 2GB.

Fixes #63.

This does not have tests because I'm not sure if we should add a test that allocates over 2GB of memory, but the testing gap bothers me.