### PR TITLE
Pass array pinning flag down to jffi

### DIFF
--- a/src/main/java/jnr/ffi/annotations/Pinned.java
+++ b/src/main/java/jnr/ffi/annotations/Pinned.java
@@ -30,6 +30,10 @@ import java.lang.annotation.Target;
  * Instead, the JVM memory is locked and passed directly to the native code.
  * </p>
  * <p>
+ * Because the data is passed to native code unconverted, care must be taken to
+ * ensure element widths align for types wider than <code>byte</code>.
+ * </p>
+ * <p>
  * <b>IMPORTANT:</b> This should not be used for functions that may block on 
  * network or filesystem access such as read(2), write(2), stat(2).
  * </p>

--- a/src/main/java/jnr/ffi/provider/jffi/AsmUtil.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmUtil.java
@@ -353,6 +353,7 @@ final class AsmUtil {
         int nflags = 0;
         nflags |= ParameterFlags.isIn(flags) ? com.kenai.jffi.ArrayFlags.IN : 0;
         nflags |= ParameterFlags.isOut(flags) ? com.kenai.jffi.ArrayFlags.OUT : 0;
+        nflags |= ParameterFlags.isPinned(flags) ? com.kenai.jffi.ArrayFlags.PINNED : 0;
         nflags |= (ParameterFlags.isNulTerminate(flags) || ParameterFlags.isIn(flags))
                 ? com.kenai.jffi.ArrayFlags.NULTERMINATE : 0;
         return nflags;

--- a/src/test/java/jnr/ffi/ArrayTest.java
+++ b/src/test/java/jnr/ffi/ArrayTest.java
@@ -21,6 +21,7 @@ package jnr.ffi;
 import jnr.ffi.annotations.LongLong;
 import jnr.ffi.annotations.In;
 import jnr.ffi.annotations.Out;
+import jnr.ffi.annotations.Pinned;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -28,6 +29,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.*;
+import java.util.function.ToLongFunction;
 
 import static org.junit.Assert.*;
 
@@ -87,6 +89,23 @@ public class ArrayTest {
         void ptr_set_double(@Out double[] p, int offset, double value);
 //        void ptr_set_pointer(@Out Pointer[] p, int offset, Pointer value);
     }
+
+    public static interface TestLibPinned {
+        byte ptr_ret_int8_t(@Pinned byte[] p, int offset);
+        short ptr_ret_int16_t(@Pinned short[] p, int offset);
+        int ptr_ret_int32_t(@Pinned int[] p, int offset);
+        @LongLong long ptr_ret_int64_t(@Pinned @LongLong long[] p, int offset);
+        long ptr_ret_int32_t(@Pinned long[] p, int offset);
+        float ptr_ret_float(@Pinned float[] p, int offset);
+        void ptr_set_int8_t(@Pinned byte[] p, int offset, byte value);
+        void ptr_set_int16_t(@Pinned short[] p, int offset, short value);
+        void ptr_set_int32_t(@Pinned int[] p, int offset, int value);
+        void ptr_set_int64_t(@Pinned @LongLong long[] p, int offset, @LongLong long value);
+        void ptr_set_int32_t(@Pinned long[] p, int offset, long value);
+        void ptr_set_float(@Pinned float[] p, int offset, float value);
+        void ptr_set_double(@Pinned double[] p, int offset, double value);
+    }
+
     static TestLib testlib;
     public ArrayTest() {
     }
@@ -221,5 +240,115 @@ public class ArrayTest {
         final byte MAGIC2 = (byte) 0xca;
         lib.ptr_set_int8_t(ref, 0, MAGIC2);
         assertEquals("byte reference not copied from native memory", MAGIC2, ref[0]);
+    }
+
+    @Test
+    public void pinnedByteByReference() {
+        TestLibPinned lib = TstUtil.loadTestLib(TestLibPinned.class);
+
+        final byte MAGIC = (byte) 0xfe;
+        byte[] ref = { MAGIC };
+
+        final byte MAGIC2 = (byte) 0xca;
+        lib.ptr_set_int8_t(ref, 0, MAGIC2);
+        assertEquals("byte reference not copied from native memory", MAGIC2, ref[0]);
+    }
+
+    @Test
+    public void pinnedIntByReference() {
+        TestLibPinned lib = TstUtil.loadTestLib(TestLibPinned.class);
+
+        // verify multi-byte values roundtrip through as expected.
+
+        final int MAGIC = 0xabcd1234;
+        int[] ref = { MAGIC, MAGIC * 2};
+
+        assertEquals(MAGIC, lib.ptr_ret_int32_t(ref, 0));
+        assertEquals(MAGIC * 2, lib.ptr_ret_int32_t(ref, 4));
+
+        final int MAGIC2 = 0xca;
+        lib.ptr_set_int32_t(ref, 0, MAGIC2);
+        assertEquals("int reference not copied from native memory", MAGIC2, ref[0]);
+    }
+
+    @Test
+    public void pinnedByteReadingFaster() {
+        TestLibInOnly lib = TstUtil.loadTestLib(TestLibInOnly.class);
+        TestLibPinned libPinned = TstUtil.loadTestLib(TestLibPinned.class);
+
+        String result = null;
+
+        ToLongFunction<Runnable> measure = (fn) -> {
+            final long deadline = System.nanoTime()
+                // 100ms windows seem to give accurate results without being
+                // unbearable.
+                + (long) (0.1 * 1e9);
+
+            long iters = 0;
+
+            // sort out about how many iterations we can do in our time and
+            // then execute that many (so that we're not timing our clock
+            // sampling).
+            while (System.nanoTime() < deadline) {
+                fn.run();
+
+                iters++;
+            }
+
+            long t0 = System.nanoTime();
+
+            for (int i = 0; i < iters; i++) {
+                fn.run();
+            }
+
+            return
+                (long) ((iters / (double) (System.nanoTime() - t0)) * 1e9);
+        };
+
+        // trying buffers sized from 4 KiB to 16 MiB
+        // the costs of copying increase substantially and rapidly as buffer
+        // size grows (especially with a cheap foreign function); it's
+        // detectable even at small buffer sizes but larger ones give a more
+        // convincing view.
+        for (int size = 1 << 12; size < 1 << 25; size <<= 1) {
+            byte[] ref = new byte[size];
+
+            long copyingsOpsPerSec
+                = measure.applyAsLong(() -> lib.ptr_ret_int8_t(ref, 0));
+
+            long pinnedOpsPerSec
+                = measure.applyAsLong(() -> libPinned.ptr_ret_int8_t(ref, 0));
+
+            double diff
+                = (copyingsOpsPerSec - pinnedOpsPerSec)
+                    / (double) pinnedOpsPerSec * 100.0;
+
+            result = String.format(
+                "bytes=% 8d diff=%.2f (ops/s copying=%d pinning=%d)",
+                size,
+                diff,
+                copyingsOpsPerSec,
+                pinnedOpsPerSec);
+
+            //System.out.println(result);
+
+            // looking for a 90% decrease (as the buffers grow this number
+            // grows ever closer to 100%).
+            if (diff < -90) {
+                return;
+            }
+        }
+
+        // XXX possible that not all VMs in all configurations will support
+        // pinning and will copy on GetPrimitiveArrayCritical. In this case
+        // this test will fail.
+        // OpenJ9 0.24 and OpenJDK 11 both appear to generally support pinning
+        // in testing, and cursory Googling seems to indicate Dalvik does as
+        // well.
+
+        fail(
+            "unable to find a buffer size at which array pinning becomes "
+            + "significantly faster. pinning non-functional? "
+            + "last test gave: " + result);
     }
 }


### PR DESCRIPTION
Pinning primitive arrays enables access to their contents in native code
without requiring copying.

The contents of the array is accessed via the GetPrimitiveArrayCritical
JNI method. Different JVMs and different JVM configurations have
different implementations and consequences of this method. In G1 (on
Hotspot in OpenJDK 11) it currently acquires a lock that prevents
garbage collection ("GCLocker") and thus can negatively impact forward
progress of mutators if a collection is required. Native methods are
thus expected to not hold these arrays for long, as is documented in JNI
docs [1] and in the `@Pinned` javadocs.

In the case that a VM is unable for some reason to avoid a copy,
GetPrimitiveArrayCritical will return a copy. This will cause test
failure: I've included a test to verify that pinning 'works': this is
the best strategy I've come up with to verify that
GetPrimitiveArrayCritical is being called as a result of the param
annotation + flag. Access to some sort of counter, if available, might
be preferrable but I'm unaware any such portable and accessible
counters.

Fortunately, OpenJDK 11 and OpenJ9's JDK 11-compatible distribution both
seem to support pinned access, as does Dalvik/ART. Given that all the
popular implementations seem to support pinning, I've left the test
enabled.

Performance benefits of pinning is significant: the attached test
displays this, as does the example at
bkgood/jnr-ffi-array-pinning-tests. I embarked on this due to
surprisingly limited performance I got in a WIP libsnappy binding: with
copying (including judicious use of `@In` and `@Out`) I get about 90
MB/s but enabling array pinning gets it closer to 250 MB/s.

This was largely implemented in jnr/jffi@a61b1fc; the requisite
flag just needs to make it to the native stubs.

Fixes #68.

[1] https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getprimitivearraycritical-releaseprimitivearraycritical