### PR TITLE
#177 Take current position into account for direct Buffer instances

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/AbstractFastNumericMethodGenerator.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AbstractFastNumericMethodGenerator.java
@@ -241,7 +241,7 @@ abstract class AbstractFastNumericMethodGenerator extends BaseMethodGenerator {
 
         } else if (Buffer.class.isAssignableFrom(javaParameterClass)) {
             mv.aload(parameter);
-            mv.invokestatic(AsmRuntime.class, "longValue", long.class, Buffer.class);
+            mv.invokestatic(BufferParameterStrategy.class, "address", long.class, Buffer.class);
             narrow(mv, long.class, nativeIntType);
             mv.aload(parameter);
             mv.invokevirtual(Buffer.class, "isDirect", boolean.class);

--- a/src/main/java/jnr/ffi/provider/jffi/AsmRuntime.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmRuntime.java
@@ -23,10 +23,8 @@ import jnr.ffi.Address;
 import jnr.ffi.Pointer;
 import jnr.ffi.mapper.ToNativeContext;
 import jnr.ffi.mapper.ToNativeConverter;
-import jnr.ffi.provider.*;
 
 import java.nio.*;
-import java.nio.charset.Charset;
 
 /**
  * Utility methods that are used at runtime by generated code.
@@ -78,14 +76,6 @@ public final class AsmRuntime {
 
     public static int intValue(Address ptr) {
         return ptr != null ? ptr.intValue() : 0;
-    }
-
-    public static long longValue(Buffer ptr) {
-        return ptr != null && ptr.isDirect() ? MemoryIO.getInstance().getDirectBufferAddress(ptr) : 0L;
-    }
-
-    public static int intValue(Buffer ptr) {
-        return ptr != null && ptr.isDirect()  ? (int) MemoryIO.getInstance().getDirectBufferAddress(ptr) : 0;
     }
 
     public static ParameterStrategy nullParameterStrategy() {

--- a/src/test/java/jnr/ffi/BufferTest.java
+++ b/src/test/java/jnr/ffi/BufferTest.java
@@ -392,4 +392,33 @@ public class BufferTest {
 //            assertEquals("Bad value at index " + i, MAGIC, buf.get(i));
 //        }
 //    }
+
+    @Test
+    public void fillDirectBufferStartingAtCurrentPosition() {
+        ByteBuffer foo = ByteBuffer.allocateDirect(SMALL);
+        foo.position(SMALL / 2);
+        fillAndCheck(foo);
+    }
+
+    @Test
+    public void fillHeapBufferStartingAtCurrentPosition() {
+        ByteBuffer fpp = ByteBuffer.allocate(SMALL);
+        fpp.position(SMALL / 2);
+        fillAndCheck(fpp);
+    }
+
+    private void fillAndCheck(ByteBuffer buffer) {
+        int startAt = buffer.position();
+        byte fillWith = (byte) 0x01;
+
+        lib.fillByteBuffer(buffer, fillWith, buffer.remaining());
+
+        buffer.position(0);
+        while (buffer.hasRemaining()) {
+            int position = buffer.position();
+            byte expected = position < startAt ? 0 : fillWith;
+            byte actual = buffer.get();
+            assertEquals("Value at position " + position + " should be " + expected, expected, actual);
+        }
+    }
 }


### PR DESCRIPTION
The added test cases illustrate the behaviour difference between heap and direct buffers. The former takes the current position into account, the latter doesn't.

I've consolidated the Buffer address calculation logic in BufferParameterStrategy since you want to keep all of those implementations consistent.

This fixes issue #177 