### PR TITLE
Added feature: Check if library exists without loading it

### DIFF
--- a/src/main/java/jnr/ffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/LibraryLoader.java
@@ -462,8 +462,8 @@ public abstract class LibraryLoader<T> {
                                      boolean failImmediately);
 
 
-    private static final class StaticDataHolder {
-        private static final List<String> USER_LIBRARY_PATH;
+    static final class StaticDataHolder {
+        static final List<String> USER_LIBRARY_PATH;
         private static void addPaths(List<String> paths, File file) {
             if (!file.isFile() || !file.exists()) return;
             BufferedReader in = null;

--- a/src/main/java/jnr/ffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/LibraryLoader.java
@@ -498,6 +498,12 @@ public abstract class LibraryLoader<T> {
             } catch (Exception ignored) {
             }
 
+            if (Platform.getNativePlatform().isUnix()) {
+                // TODO basshelal Add the Unix default lib paths
+                //  then put the ld.so.conf code here for more
+                //  but make sure we don't add the same dir twice
+            }
+
             switch (Platform.getNativePlatform().getOS()) {
                 case FREEBSD:
                 case OPENBSD:
@@ -533,6 +539,8 @@ public abstract class LibraryLoader<T> {
         String value = System.getProperty(propName);
         if (value != null) {
             String[] paths = value.split(File.pathSeparator);
+            System.out.println(propName);
+            System.out.println(Arrays.toString(paths));
             return new ArrayList<String>(Arrays.asList(paths));
         }
         return Collections.emptyList();

--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -431,24 +431,23 @@ public abstract class Platform {
     }
 
     /**
-     * Checks to see if a library will be found, you can use this to see if the system has a library installed,
-     * useful to check if an optional library exists (such as JACK, "libjack.so") without having to load it.
+     * Returns a list of absolute paths to the found locations of a library with the base name {@code libName},
+     * if the returned list is empty then the library could not be found and will fail to be loaded.
      *
-     * This checks the default library directories in addition to the paths provided in {@code libPaths}
+     * Even if a library is found, this does not guarantee that it will successfully be loaded, it only guarantees
+     * that the reason for the failure was not that it was not found.
      *
-     * @param libName  the base name (e.g. "c") of the library to locate
-     * @param libPaths the list of directories to search, or null if checking the system
-     * @return true if the library was found, false otherwise
+     * @param libName         the base name (e.g. "c") of the library to locate
+     * @param additionalPaths additional paths to search, these take precedence over default paths,
+     *                        (as is the behavior in {@link LibraryLoader})
+     *                        pass null or an empty list to only search in the default paths
+     * @return the list of absolute paths where the library was found
      */
-    public boolean canFindLibrary(String libName, List<String> libPaths) {
-        // TODO basshelal remove? in favor of just libraryLocations
-        return !libraryLocations(libName, libPaths).isEmpty();
-    }
-
     public List<String> libraryLocations(String libName, List<String> additionalPaths) {
         ArrayList<String> result = new ArrayList<>();
-        ArrayList<String> libDirs = new ArrayList<>(LibraryLoader.DefaultLibPaths.PATHS);
-        if (additionalPaths != null) libDirs.addAll(additionalPaths);
+        ArrayList<String> libDirs = new ArrayList<>();
+        if (additionalPaths != null) libDirs.addAll(additionalPaths); // customPaths first!
+        libDirs.addAll(LibraryLoader.DefaultLibPaths.PATHS);
 
         // locateLibrary can either give us an absolute path with the version at the end (for Linux)
         //  or just the name (forwards to mapLibraryName), either way we only want the name, we will

--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -20,6 +20,7 @@ package jnr.ffi;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -428,6 +429,32 @@ public abstract class Platform {
         // Default to letting the system search for it
         return mappedName;
     }
+
+    /**
+     * Checks to see if a library will be found, you can use this to see if the system has a library installed,
+     * useful to check if an optional library exists (such as JACK, "libjack.so") without having to load it.
+     *
+     * This checks the default library directories in addition to the paths provided in {@code libPaths}
+     *
+     * @param libName  the base name (e.g. "c") of the library to locate
+     * @param libPaths the list of directories to search, or null if checking the system
+     * @return true if the library was found, false otherwise
+     */
+    public boolean canFindLibrary(String libName, List<String> libPaths) {
+        ArrayList<String> paths = new ArrayList<>(LibraryLoader.StaticDataHolder.USER_LIBRARY_PATH);
+        if (libPaths != null) paths.addAll(libPaths);
+
+        // locateLibrary can either give us an absolute path with the version at the end (for Linux)
+        //  or just the name (forwards to mapLibraryName), either way we only want the name, we will
+        //  add the parent later from paths
+        String name = new File(locateLibrary(libName, paths)).getName();
+        for (String path : paths) {
+            File libFile = new File(path, name);
+            if (libFile.exists()) return true;
+        }
+        return false;
+    }
+
     private static class Supported extends Platform {
         public Supported(OS os) {
             super(os);

--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -432,7 +432,7 @@ public abstract class Platform {
 
     /**
      * Returns a list of absolute paths to the found locations of a library with the base name {@code libName},
-     * if the returned list is empty then the library could not be found and will fail to be loaded.
+     * if the returned list is empty then the library could not be found and will fail to be loaded as a result.
      *
      * Even if a library is found, this does not guarantee that it will successfully be loaded, it only guarantees
      * that the reason for the failure was not that it was not found.
@@ -440,7 +440,7 @@ public abstract class Platform {
      * @param libName         the base name (e.g. "c") of the library to locate
      * @param additionalPaths additional paths to search, these take precedence over default paths,
      *                        (as is the behavior in {@link LibraryLoader})
-     *                        pass null or an empty list to only search in the default paths
+     *                        pass null to only search in the default paths
      * @return the list of absolute paths where the library was found
      */
     public List<String> libraryLocations(String libName, List<String> additionalPaths) {

--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -441,18 +441,26 @@ public abstract class Platform {
      * @return true if the library was found, false otherwise
      */
     public boolean canFindLibrary(String libName, List<String> libPaths) {
-        ArrayList<String> paths = new ArrayList<>(LibraryLoader.StaticDataHolder.USER_LIBRARY_PATH);
-        if (libPaths != null) paths.addAll(libPaths);
+        // TODO basshelal remove? in favor of just libraryLocations
+        return !libraryLocations(libName, libPaths).isEmpty();
+    }
+
+    public List<String> libraryLocations(String libName, List<String> additionalPaths) {
+        ArrayList<String> result = new ArrayList<>();
+        ArrayList<String> libDirs = new ArrayList<>(LibraryLoader.DefaultLibPaths.PATHS);
+        if (additionalPaths != null) libDirs.addAll(additionalPaths);
 
         // locateLibrary can either give us an absolute path with the version at the end (for Linux)
         //  or just the name (forwards to mapLibraryName), either way we only want the name, we will
-        //  add the parent later from paths
-        String name = new File(locateLibrary(libName, paths)).getName();
-        for (String path : paths) {
-            File libFile = new File(path, name);
-            if (libFile.exists()) return true;
+        //  add the parent later from libDirs
+        String name = new File(locateLibrary(libName, libDirs)).getName();
+        for (String libDir : libDirs) {
+            File libFile = new File(libDir, name);
+            if (libFile.exists()) {
+                result.add(libFile.getAbsolutePath());
+            }
         }
-        return false;
+        return result;
     }
 
     private static class Supported extends Platform {

--- a/src/test/java/jnr/ffi/PlatformTest.java
+++ b/src/test/java/jnr/ffi/PlatformTest.java
@@ -91,4 +91,18 @@ public class PlatformTest {
     public void testMultiComponentVersionComparison() throws Exception {
         testVersionComparison("42.1.3.4", "", "5", "6.1", "42", "42.1", "42.0.5", "42.1.3.4");
     }
+
+    @Test
+    public void testCanFindLibrary() {
+        Platform platform = Platform.getNativePlatform();
+        Assert.assertFalse(platform.canFindLibrary("shouldNotFind", null));
+        Assert.assertTrue(platform.canFindLibrary("test", null));
+
+        Assert.assertTrue(platform.canFindLibrary("c", null));
+
+        if (platform.getOS() == Platform.OS.LINUX) {
+            // try known system lib
+            Assert.assertTrue(platform.canFindLibrary("curl", null));
+        }
+    }
 }

--- a/src/test/java/jnr/ffi/PlatformTest.java
+++ b/src/test/java/jnr/ffi/PlatformTest.java
@@ -98,8 +98,6 @@ public class PlatformTest {
         Assert.assertFalse(platform.canFindLibrary("shouldNotFind", null));
         Assert.assertTrue(platform.canFindLibrary("test", null));
 
-        Assert.assertTrue(platform.canFindLibrary("c", null));
-
         if (platform.getOS() == Platform.OS.LINUX) {
             // try known system lib
             Assert.assertTrue(platform.canFindLibrary("curl", null));

--- a/src/test/java/jnr/ffi/PlatformTest.java
+++ b/src/test/java/jnr/ffi/PlatformTest.java
@@ -92,15 +92,13 @@ public class PlatformTest {
         testVersionComparison("42.1.3.4", "", "5", "6.1", "42", "42.1", "42.0.5", "42.1.3.4");
     }
 
+    // TODO basshelal test should really just ensure that we are truthful and that if we said it was found,
+    //  the library would successfully load later, and of course the reverse, BUT a load error because of badly named
+    //  or symbols not found is not on us
     @Test
     public void testCanFindLibrary() {
         Platform platform = Platform.getNativePlatform();
-        Assert.assertFalse(platform.canFindLibrary("shouldNotFind", null));
-        Assert.assertTrue(platform.canFindLibrary("test", null));
 
-        if (platform.getOS() == Platform.OS.LINUX) {
-            // try known system lib
-            Assert.assertTrue(platform.canFindLibrary("curl", null));
-        }
+        System.out.println(platform.libraryLocations("asound", null));
     }
 }

--- a/src/test/java/jnr/ffi/PlatformTest.java
+++ b/src/test/java/jnr/ffi/PlatformTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 public class PlatformTest {
     private File tmpDir;
@@ -92,13 +94,52 @@ public class PlatformTest {
         testVersionComparison("42.1.3.4", "", "5", "6.1", "42", "42.1", "42.0.5", "42.1.3.4");
     }
 
-    // TODO basshelal test should really just ensure that we are truthful and that if we said it was found,
-    //  the library would successfully load later, and of course the reverse, BUT a load error because of badly named
-    //  or symbols not found is not on us
+    // library should not be found AND should fail to load
     @Test
-    public void testCanFindLibrary() {
-        Platform platform = Platform.getNativePlatform();
+    public void testLibraryLocationsFailNotFound() {
+        String libName = "should-not-find-me";
+        List<String> libLocations = Platform.getNativePlatform().libraryLocations(libName, null);
+        Assert.assertTrue(libLocations.isEmpty());
+        boolean failed = false;
+        try {
+            LibraryLoader.loadLibrary(TestLib.class, new HashMap<>(), libName);
+        } catch (LinkageError e) {
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+    }
 
-        System.out.println(platform.libraryLocations("asound", null));
+    // library should be found but client had unknown symbols, so failed to load even though it exists
+    @Test
+    public void testLibraryLocationsFailBadSymbol() {
+        String libName = "test";
+        List<String> libLocations = Platform.getNativePlatform().libraryLocations(libName, null);
+        Assert.assertFalse(libLocations.isEmpty());
+        boolean failed = false;
+        try {
+            TestLibIncorrect lib = LibraryLoader.loadLibrary(TestLibIncorrect.class, new HashMap<>(), libName);
+            lib.incorrectFunctionShouldNotBeFound(0);
+        } catch (LinkageError e) {
+            failed = true;
+        }
+        Assert.assertTrue(failed);
+    }
+
+    // library should be found AND should load correctly because correct symbols
+    @Test
+    public void testLibraryLocationsSuccessful() {
+        String libName = "test";
+        List<String> libLocations = Platform.getNativePlatform().libraryLocations(libName, null);
+        Assert.assertFalse(libLocations.isEmpty());
+        TestLib lib = LibraryLoader.loadLibrary(TestLib.class, new HashMap<>(), libName); // should succeed
+        Assert.assertNotNull(lib);
+    }
+
+    public static interface TestLib {
+        int setLastError(int error);
+    }
+
+    public static interface TestLibIncorrect {
+        int incorrectFunctionShouldNotBeFound(int error);
     }
 }


### PR DESCRIPTION
This gives callers a way to determine if the system will find the library with the passed in name in the system library default locations in addition to the optional passed in additional paths, without having to try to the load the library, so that callers are aware of missing libraries early.

This fixes https://github.com/jnr/jnr-ffi/issues/228