### PR TITLE
Preliminary armple support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.3.3-SNAPSHOT</version>
+      <version>1.3.3</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.3.3-SNAPSHOT</version>
+      <version>1.3.3</version>
       <scope>runtime</scope>
       <classifier>native</classifier>
     </dependency>


### PR DESCRIPTION
This updates JFFI to get preliminary support for Apple Silicon (armple). Varargs are still broken but everything else works.

See https://github.com/jnr/jffi/issues/105 for ongoing work on varargs on armple.