### PR TITLE
Fix TypeAliases for aarch64 linux

### DIFF
--- a/src/main/java/jnr/ffi/provider/jffi/platform/aarch64/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/aarch64/linux/TypeAliases.java
@@ -41,7 +41,7 @@ public final class TypeAliases {
         m.put(TypeAlias.caddr_t, NativeType.ADDRESS);
         m.put(TypeAlias.dev_t, NativeType.ULONG);
         m.put(TypeAlias.blkcnt_t, NativeType.SLONG);
-        m.put(TypeAlias.blksize_t, NativeType.SLONG);
+        m.put(TypeAlias.blksize_t, NativeType.SINT);
         m.put(TypeAlias.gid_t, NativeType.UINT);
         m.put(TypeAlias.in_addr_t, NativeType.UINT);
         m.put(TypeAlias.in_port_t, NativeType.USHORT);
@@ -49,7 +49,7 @@ public final class TypeAliases {
         m.put(TypeAlias.ino64_t, NativeType.ULONG);
         m.put(TypeAlias.key_t, NativeType.SINT);
         m.put(TypeAlias.mode_t, NativeType.UINT);
-        m.put(TypeAlias.nlink_t, NativeType.ULONG);
+        m.put(TypeAlias.nlink_t, NativeType.UINT);
         m.put(TypeAlias.id_t, NativeType.UINT);
         m.put(TypeAlias.pid_t, NativeType.SINT);
         m.put(TypeAlias.off_t, NativeType.SLONG);


### PR DESCRIPTION
`blksize_t` and `nlink_t` are incorrectly defined for aarch64 linux.

This currently manifests itself when using `File.stat` in jruby, where
the `uid`, `gid`, and `nlink` values are incorrect.

The value of `nlink_t` is defined as follows:

```
/usr/include/bits/stat.h:    __nlink_t st_nlink;		/* Link count.  */
/usr/include/bits/types.h:__STD_TYPE __NLINK_T_TYPE __nlink_t;	/* Type of file link counts.  */
/usr/include/bits/typesizes.h:#define __NLINK_T_TYPE		__U32_TYPE
```

The value of `blksize_t` is defined as follows:

```
/usr/include/bits/stat.h:    __blksize_t st_blksize;	/* Optimal block size for I/O.  */
/usr/include/bits/types.h:__STD_TYPE __BLKSIZE_T_TYPE __blksize_t;
/usr/include/bits/typesizes.h:#define __BLKSIZE_T_TYPE	__S32_TYPE
```

This commit updates the type aliases for these types to match correctly.

Relates: https://github.com/jnr/jnr-ffi/issues/240