### PR TITLE
Handle default methods in proxied interfaces

### DIFF
--- a/src/main/java/jnr/ffi/provider/FFIProvider.java
+++ b/src/main/java/jnr/ffi/provider/FFIProvider.java
@@ -20,6 +20,8 @@ package jnr.ffi.provider;
 
 import jnr.ffi.LibraryLoader;
 
+import java.lang.invoke.MethodHandles;
+
 /**
  * This class defines the facilities a JNR FFI provider must provide.
  *
@@ -52,6 +54,16 @@ public abstract class FFIProvider {
      *  @return the {@code LibraryLoader} instance.
      */
     public abstract <T> LibraryLoader<T> createLibraryLoader(Class<T> interfaceClass);
+
+    /**
+     * Creates a new {@link LibraryLoader} instance.
+     *
+     * @param <T> The library type.
+     * @param interfaceClass The library interface class.
+     * @param lookup the {@link java.lang.invoke.MethodHandles.Lookup} to use for invoking default functions
+     * @return the {@code LibraryLoader} instance.
+     */
+    public abstract <T> LibraryLoader<T> createLibraryLoader(Class<T> interfaceClass, MethodHandles.Lookup lookup);
 
     private static final class SystemProviderSingletonHolder {
         private static final FFIProvider INSTANCE = getInstance();

--- a/src/main/java/jnr/ffi/provider/InvalidProvider.java
+++ b/src/main/java/jnr/ffi/provider/InvalidProvider.java
@@ -22,6 +22,7 @@ import jnr.ffi.LibraryLoader;
 import jnr.ffi.LibraryOption;
 import jnr.ffi.Runtime;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Map;
 
@@ -45,11 +46,16 @@ final class InvalidProvider extends FFIProvider {
     public <T> LibraryLoader<T> createLibraryLoader(Class<T> interfaceClass) {
         return new LibraryLoader<T>(interfaceClass) {
             @Override
-            protected T loadLibrary(Class<T> interfaceClass, Collection<String> libraryNames, Collection<String> searchPaths, Map<LibraryOption, Object> options, boolean failImmediately) {
+            protected T loadLibrary(Class<T> interfaceClass, MethodHandles.Lookup lookup, Collection<String> libraryNames, Collection<String> searchPaths, Map<LibraryOption, Object> options, boolean failImmediately) {
                 UnsatisfiedLinkError error = new UnsatisfiedLinkError(message);
                 error.initCause(cause);
                 throw error;
             }
         };
+    }
+
+    @Override
+    public <T> LibraryLoader<T> createLibraryLoader(Class<T> interfaceClass, MethodHandles.Lookup lookup) {
+        return createLibraryLoader(interfaceClass);
     }
 }

--- a/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/AsmLibraryLoader.java
@@ -43,6 +43,7 @@ import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.ClassWriter;
 
 import java.io.PrintWriter;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
@@ -72,8 +73,13 @@ public class AsmLibraryLoader extends LibraryLoader {
     private final NativeRuntime runtime = NativeRuntime.getInstance();
 
     @Override
-    <T> T loadLibrary(NativeLibrary library, Class<T> interfaceClass, Map<LibraryOption, ?> libraryOptions,
-                      boolean failImmediately /* ignored, asm loader eagerly binds everything */) {
+    <T> T loadLibrary(
+            NativeLibrary library,
+            Class<T> interfaceClass,
+            MethodHandles.Lookup lookup /* ignored, asm loader avoids binding default methods */,
+            Map<LibraryOption, ?> libraryOptions,
+            boolean failImmediately /* ignored, asm loader eagerly binds everything */) {
+
         AsmClassLoader oldClassLoader = classLoader.get();
 
         // Only create a new class loader if this was not a recursive call (i.e. loading a library as a result of loading another library)

--- a/src/main/java/jnr/ffi/provider/jffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/LibraryLoader.java
@@ -27,6 +27,7 @@ import jnr.ffi.mapper.SignatureTypeMapperAdapter;
 import jnr.ffi.mapper.TypeMapper;
 import jnr.ffi.provider.NullTypeMapper;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 public abstract class LibraryLoader {
@@ -60,5 +61,5 @@ public abstract class LibraryLoader {
                     new CachingTypeMapper(new AnnotationTypeMapper()));
     }
 
-    abstract <T> T loadLibrary(NativeLibrary library, Class<T> interfaceClass, Map<LibraryOption, ?> libraryOptions, boolean failImmediately);
+    abstract <T> T loadLibrary(NativeLibrary library, Class<T> interfaceClass, MethodHandles.Lookup lookup, Map<LibraryOption, ?> libraryOptions, boolean failImmediately);
 }

--- a/src/main/java/jnr/ffi/provider/jffi/NativeLibraryLoader.java
+++ b/src/main/java/jnr/ffi/provider/jffi/NativeLibraryLoader.java
@@ -20,6 +20,7 @@ package jnr.ffi.provider.jffi;
 
 import jnr.ffi.LibraryOption;
 
+import java.lang.invoke.MethodHandles;
 import java.util.Collection;
 import java.util.Map;
 
@@ -35,14 +36,18 @@ class NativeLibraryLoader<T>  extends jnr.ffi.LibraryLoader<T> {
         super(interfaceClass);
     }
 
-    public T loadLibrary(Class<T> interfaceClass, Collection<String> libraryNames, Collection<String> searchPaths,
-                             Map<LibraryOption, Object> options, boolean failImmediately) {
+    NativeLibraryLoader(Class<T> interfaceClass, MethodHandles.Lookup lookup) {
+        super(interfaceClass, lookup);
+    }
+
+    public T loadLibrary(Class<T> interfaceClass, MethodHandles.Lookup lookup, Collection<String> libraryNames, Collection<String> searchPaths,
+                         Map<LibraryOption, Object> options, boolean failImmediately) {
         NativeLibrary nativeLibrary = new NativeLibrary(libraryNames, searchPaths);
 
         try {
             return ASM_ENABLED
-                ? new AsmLibraryLoader().loadLibrary(nativeLibrary, interfaceClass, options, failImmediately)
-                : new ReflectionLibraryLoader().loadLibrary(nativeLibrary, interfaceClass, options, failImmediately);
+                ? new AsmLibraryLoader().loadLibrary(nativeLibrary, interfaceClass, lookup, options, failImmediately)
+                : new ReflectionLibraryLoader().loadLibrary(nativeLibrary, interfaceClass, lookup, options, failImmediately);
 
         } catch (RuntimeException ex) {
             throw ex;

--- a/src/main/java/jnr/ffi/provider/jffi/Provider.java
+++ b/src/main/java/jnr/ffi/provider/jffi/Provider.java
@@ -21,6 +21,8 @@ package jnr.ffi.provider.jffi;
 import jnr.ffi.Runtime;
 import jnr.ffi.provider.FFIProvider;
 
+import java.lang.invoke.MethodHandles;
+
 
 public final class Provider extends FFIProvider {
     private final NativeRuntime runtime;
@@ -35,5 +37,9 @@ public final class Provider extends FFIProvider {
 
     public <T> jnr.ffi.LibraryLoader<T> createLibraryLoader(Class<T> interfaceClass) {
         return new NativeLibraryLoader<T>(interfaceClass);
+    }
+
+    public <T> jnr.ffi.LibraryLoader<T> createLibraryLoader(Class<T> interfaceClass, MethodHandles.Lookup lookup) {
+        return new NativeLibraryLoader<T>(interfaceClass, lookup);
     }
 }

--- a/src/test/java/jnr/ffi/InvocationTest.java
+++ b/src/test/java/jnr/ffi/InvocationTest.java
@@ -21,6 +21,8 @@ package jnr.ffi;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.lang.invoke.MethodHandles;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -29,6 +31,14 @@ import static org.junit.Assert.assertEquals;
 public class InvocationTest {
     public static interface TestLib {
         int ret_int32_t(int i);
+    }
+
+    public static interface TestLibWithDefault {
+        static final MethodHandles.Lookup lookup = MethodHandles.lookup();
+        int ret_int32_t(int i);
+        default int doesNotExist(int i) {
+            return ret_int32_t(i);
+        }
     }
 
     static TestLib testlib;
@@ -43,5 +53,12 @@ public class InvocationTest {
         for (int i = 0; i < 1000000; i++) {
             assertEquals(i, testlib.ret_int32_t(i));
         }
+    }
+
+    @Test
+    public void testDefault() throws Throwable {
+        TestLibWithDefault withDefault = TstUtil.loadTestLib(TestLibWithDefault.class, TestLibWithDefault.lookup);
+
+        assertEquals(testlib.ret_int32_t(1234), withDefault.doesNotExist(1234));
     }
 }

--- a/src/test/java/jnr/ffi/TstUtil.java
+++ b/src/test/java/jnr/ffi/TstUtil.java
@@ -20,6 +20,7 @@ package jnr.ffi;
 
 import jnr.ffi.provider.FFIProvider;
 
+import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
@@ -42,11 +43,20 @@ public final class TstUtil {
     }
 
     public static <T> T loadTestLib(Class<T> interfaceClass) {
-        final Map<LibraryOption, ?> options = Collections.emptyMap();
-        return loadTestLib(interfaceClass, options);
+        return loadTestLib(interfaceClass, (MethodHandles.Lookup) null);
     }
+
+    public static <T> T loadTestLib(Class<T> interfaceClass, MethodHandles.Lookup lookup) {
+        final Map<LibraryOption, ?> options = Collections.emptyMap();
+        return loadTestLib(interfaceClass, lookup, options);
+    }
+
     public static <T> T loadTestLib(Class<T> interfaceClass, Map<LibraryOption, ?> options) {
-        LibraryLoader<T> loader = (provider != null ? provider : FFIProvider.getSystemProvider()).createLibraryLoader(interfaceClass);
+        return loadTestLib(interfaceClass, null, options);
+    }
+
+    public static <T> T loadTestLib(Class<T> interfaceClass, MethodHandles.Lookup lookup, Map<LibraryOption, ?> options) {
+        LibraryLoader<T> loader = (provider != null ? provider : FFIProvider.getSystemProvider()).createLibraryLoader(interfaceClass, lookup);
 
         loader.library(libname);
         for (Map.Entry<LibraryOption, ?> option : options.entrySet()) {


### PR DESCRIPTION
It turns out java.lang.Proxy works very poorly in the presence of interface default methods, leading to the issues described in #249. This PR is a prototype of logic to handle such methods using method handles, which works on Java 8-16.

This code is a little heinous, and requires the user (providing the interface) to also have a Lookup object acquired from within that interface, in order to dispatch to the "special" default method bodies.

Java 16 adds a standard way to redispatch to default methods, and the user-side Lookup requirement here is rather heinous, so this may be something we just make a hard error unless we are running on 16.

Fixes #249.