### PR TITLE
Remove default search paths for Unix systems

### DIFF
--- a/src/main/java/jnr/ffi/LibraryLoader.java
+++ b/src/main/java/jnr/ffi/LibraryLoader.java
@@ -508,13 +508,6 @@ public abstract class LibraryLoader<T> {
             } catch (Exception ignored) {
             }
 
-            if (Platform.getNativePlatform().isUnix()) {
-                // order is intentional!
-                paths.add("/usr/local/lib");
-                paths.add("/usr/lib");
-                paths.add("/lib");
-            }
-
             switch (Platform.getNativePlatform().getOS()) {
                 case FREEBSD:
                 case OPENBSD:


### PR DESCRIPTION
The JDK already includes the default search paths for Unix/Linux through it's system property `java.library.path`

You can see the default path set by the JDK for Unix/Linux [here]( https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/master/hotspot/src/os/linux/vm/os_linux.cpp#L371)

In an effort to enforce reproducibility for the [NixOS](https://nixos.org/) project, we've recently patched the JDK8 to clear out the default `java.library.path` - https://github.com/NixOS/nixpkgs/pull/123708

Unfortunately, this does not bubble up to thejnr-ffi gem since they additionally hardcode the values.

This contribution removes that hardcoded list. In the normal case, the list remains the same since it will get the default list through `java.library.path` however now it can be cleared out appropriately.