### PR TITLE
JUnit should be in `test` scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>5.7.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>


### PR DESCRIPTION
Fixes a regression caused by #252, which removed the `test` scope from JUnit. As a result, the following JARs are now `compile`-scoped dependencies:

```
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.7.2:compile
[INFO] |  +- org.apiguardian:apiguardian-api:jar:1.1.0:compile
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.7.2:compile
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:compile
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.7.2:compile
[INFO] |  \- org.junit.jupiter:junit-jupiter-api:jar:5.7.2:compile
```

Their mere presence on the classpath exposed Jenkins core to [SUREFIRE-1911](https://issues.apache.org/jira/browse/SUREFIRE-1911).

Surely this was an oversight. This PR corrects the problem by putting JUnit in `test` scope.