### PR TITLE
Added methods to `Platform` to check platform version

### DIFF
--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -397,6 +397,48 @@ public abstract class Platform {
     }
 
     /**
+     * Gets the version of this platform as specified by the system property "os.version"
+     * @return the String representing the version of this platform, or null if none could be found
+     */
+    public String getVersion() {
+        return System.getProperty("os.version", null);
+    }
+
+    /**
+     * @return the list of version numbers found from {@link #getVersion()} or an empty list if none were found
+     */
+    private List<String> getVersionNumbers() {
+        String version = getVersion();
+        if (version == null) return Collections.emptyList();
+        Matcher matcher = Pattern.compile("[\\d]+").matcher(version); // get digits only
+        ArrayList<String> result = new ArrayList<>();
+        while (matcher.find()) {
+            result.add(matcher.group());
+        }
+        return result;
+    }
+
+    /**
+     * Gets the number representing the major version of this platform
+     * This uses the first number from {@link #getVersion()}
+     * @return the number representing the major version of this platform or -1 if none was found
+     */
+    public int getVersionMajor() {
+        List<String> versionNumbers = getVersionNumbers();
+        return versionNumbers.size() < 1 ? -1 : Integer.parseInt(versionNumbers.get(0));
+    }
+
+    /**
+     * Gets the number representing the minor version of this platform
+     * This uses the second number from {@link #getVersion()}
+     * @return the number representing the minor version of this platform or -1 if none was found
+     */
+    public int getVersionMinor() {
+        List<String> versionNumbers = getVersionNumbers();
+        return versionNumbers.size() < 2 ? -1 : Integer.parseInt(versionNumbers.get(1));
+    }
+
+    /**
      * Returns the platform specific standard C library name
      * 
      * @return The standard C library name

--- a/src/test/java/jnr/ffi/PlatformTest.java
+++ b/src/test/java/jnr/ffi/PlatformTest.java
@@ -274,4 +274,29 @@ public class PlatformTest {
         assertEquals(customSystemPath, locatedFile.getParentFile().getAbsolutePath());
     }
 
+    @Test
+    public void testGetVersion() {
+        String originalVersion = System.getProperty("os.version");
+        assumeTrue(originalVersion != null);
+        assertEquals(originalVersion, Platform.getNativePlatform().getVersion());
+        try {
+            String[] versionStrings = new String[]{
+                    "5.11.0-69420-generic",     // GNU/Linux
+                    "10.16",                    // Darwin
+                    "10.0",                     // Windows
+                    " wildcard-123-456",        // wildcard
+            };
+            for (String version : versionStrings) {
+                System.setProperty("os.version", version);
+                int major = Platform.getNativePlatform().getVersionMajor();
+                int minor = Platform.getNativePlatform().getVersionMinor();
+                assertNotEquals(-1, major);
+                assertNotEquals(-1, minor);
+            }
+        } finally { // even if test fails reset version to what it was before
+            System.setProperty("os.version", originalVersion);
+            assertEquals(originalVersion, System.getProperty("os.version"));
+        }
+    }
+
 }


### PR DESCRIPTION
* `String getVersion()` gets the system property "os.version" or `null` if it wasn't found
* `int getVersionMajor()` gets the "major" version number, that is the first number from `getVersion()` or -1 if none could be found
* `int getVersionMinor()` gets the "minor" version number, that is the second number from `getVersion()` or -1 if none could be found

Added a single unit test to verify all of the above.

This is regarding merging the hack from https://github.com/jnr/jnr-enxio/pull/39 to a more centralized location

Addresses but does not yet complete https://github.com/jnr/jnr-ffi/issues/260