### PR TITLE
Fix issue where AsciiStringRef.set() and UTF8StringRef.set() would throw an IllegalArgumentException.

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -20,7 +20,7 @@
  *
  * Copyright (C) 2006 - Javolution (http://javolution.org/)
  * All rights reserved.
- * 
+ *
  * Permission to use, copy, modify, and distribute this software is
  * freely granted, provided that this notice is preserved.
  */
@@ -2370,8 +2370,8 @@ public abstract class Struct {
 
         public final void set(java.lang.String value) {
             if (value != null) {
-                valueHolder = getRuntime().getMemoryManager().allocateDirect(length() * 4);
-                valueHolder.putString(0, value, length() * 4, charset);
+                valueHolder = getRuntime().getMemoryManager().allocateDirect(value.length() * 4);
+                valueHolder.putString(0, value, value.length() * 4, charset);
                 getMemory().putPointer(offset(), valueHolder);
 
             } else {

--- a/src/test/java/jnr/ffi/struct/AsciiStringFieldTest.java
+++ b/src/test/java/jnr/ffi/struct/AsciiStringFieldTest.java
@@ -84,4 +84,21 @@ public class AsciiStringFieldTest {
         testlib.copyByteBuffer(tmp, s, s.string.length());
         assertEquals(MAGIC, tmp.toString(), "String not put into struct correctly");
     }
+
+    public static final class StructWithStringByRef extends Struct {
+        private final AsciiStringRef stringValue = new AsciiStringRef();
+
+        public StructWithStringByRef() {
+            super(runtime);
+        }
+    }
+
+    @Test public void testStringByRef() {
+        final String testValue = "some test string";
+        final StructWithStringByRef struct = new StructWithStringByRef();
+
+        struct.stringValue.set(testValue);
+
+        assertEquals(testValue, struct.stringValue.get());
+    }
 }

--- a/src/test/java/jnr/ffi/struct/UTF8StringFieldTest.java
+++ b/src/test/java/jnr/ffi/struct/UTF8StringFieldTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class UTF8StringFieldTest {
     public UTF8StringFieldTest() {
     }
-    
+
     public static class StringFieldStruct extends Struct {
         public final UTF8String string = new UTF8String(32);
 
@@ -104,5 +104,22 @@ public class UTF8StringFieldTest {
         assertEquals(SUN_LEN, s.sun_len.intValue(), "Incorrect sun_len value");
         assertEquals(SUN_FAM, s.sun_family.intValue(), "Incorrect sun_fam value");
         assertEquals(SUN_PATH, s.sun_path.toString(), "Incorrect sun_path value");
+    }
+
+    public static final class StructWithStringByRef extends Struct {
+        private final UTF8StringRef stringValue = new UTF8StringRef();
+
+        public StructWithStringByRef() {
+            super(runtime);
+        }
+    }
+
+    @Test public void testStringByRef() {
+        final String testValue = "some test string";
+        final StructWithStringByRef struct = new StructWithStringByRef();
+
+        struct.stringValue.set(testValue);
+
+        assertEquals(testValue, struct.stringValue.get());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/jnr/jnr-ffi/issues/159.

I've added a basic test case for the scenario that fails without this fix and passes with the fix.

I'm not sure if my changes are correct though:
* should `UTFStringRef.set()` also update `this.length` to the length of the new string value?
* should we be allocating additional space for the null terminator character in the call to `getRuntime().getMemoryManager().allocateDirect()`?