### PR TITLE
Fix issue where string references aren't always completed with a null terminator.

### DIFF
--- a/src/main/java/jnr/ffi/Struct.java
+++ b/src/main/java/jnr/ffi/Struct.java
@@ -2469,8 +2469,9 @@ public abstract class Struct {
 
         public final void set(java.lang.String value) {
             if (value != null) {
-                valueHolder = getRuntime().getMemoryManager().allocateDirect(value.length() * 4);
-                valueHolder.putString(0, value, value.length() * 4, charset);
+                int maxBytes = (value.length() * 4) + 1; // Additional byte required for trailing null termination.
+                valueHolder = getRuntime().getMemoryManager().allocateDirect(maxBytes);
+                valueHolder.putString(0, value, maxBytes, charset);
                 getMemory().putPointer(offset(), valueHolder);
 
             } else {

--- a/src/test/java/jnr/ffi/struct/AsciiStringFieldTest.java
+++ b/src/test/java/jnr/ffi/struct/AsciiStringFieldTest.java
@@ -101,4 +101,24 @@ public class AsciiStringFieldTest {
 
         assertEquals(testValue, struct.stringValue.get());
     }
+
+    public static final class StructWithConsecutiveStringsByRef extends Struct {
+        private final AsciiStringRef firstValue = new AsciiStringRef();
+        private final AsciiStringRef secondValue = new AsciiStringRef();
+
+        public StructWithConsecutiveStringsByRef() {
+            super(runtime);
+        }
+    }
+
+    @Test public void testStructWithConsecutiveStringsByRef() {
+        final String testValue = "some test string";
+        final StructWithConsecutiveStringsByRef struct = new StructWithConsecutiveStringsByRef();
+
+        struct.firstValue.set("");
+        struct.secondValue.set(testValue);
+
+        assertEquals("", struct.firstValue.get());
+        assertEquals(testValue, struct.secondValue.get());
+    }
 }

--- a/src/test/java/jnr/ffi/struct/UTF8StringFieldTest.java
+++ b/src/test/java/jnr/ffi/struct/UTF8StringFieldTest.java
@@ -122,4 +122,24 @@ public class UTF8StringFieldTest {
 
         assertEquals(testValue, struct.stringValue.get());
     }
+
+    public static final class StructWithConsecutiveStringsByRef extends Struct {
+        private final UTF8StringRef firstValue = new UTF8StringRef();
+        private final UTF8StringRef secondValue = new UTF8StringRef();
+
+        public StructWithConsecutiveStringsByRef() {
+            super(runtime);
+        }
+    }
+
+    @Test public void testStructWithConsecutiveStringsByRef() {
+        final String testValue = "some test string";
+        final StructWithConsecutiveStringsByRef struct = new StructWithConsecutiveStringsByRef();
+
+        struct.firstValue.set("");
+        struct.secondValue.set(testValue);
+
+        assertEquals("", struct.firstValue.get());
+        assertEquals(testValue, struct.secondValue.get());
+    }
 }


### PR DESCRIPTION
The existing implementation works most of the time because most characters don't consume the full four bytes a single UTF-8 character could consume. An empty string is a good example of where this falls down.

The tests rely on the fact that two consecutive memory allocations usually end up next to each other. This happens reliably for me on my machine, but isn't guaranteed. If there's a better way to test this, I'd love to hear it.

Resolves #276.