### PR TITLE
Use jffi-1.3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.11</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.3.10</version>
+      <version>1.3.11</version>
       <scope>runtime</scope>
       <classifier>native</classifier>
     </dependency>


### PR DESCRIPTION
This PR is to update to and test against the new debian:8 build of jffi from jnr/jffi#140, intended to fix jnr/jffi#138.

Update to the released version (not snapshot) before merging.