### PR TITLE
Add riscv64 linux support

### DIFF
--- a/src/main/java/jnr/ffi/Platform.java
+++ b/src/main/java/jnr/ffi/Platform.java
@@ -130,6 +130,9 @@ public abstract class Platform {
         /** 64 bit LOONGARCH */
         LOONGARCH64,
 
+        /** 64 bit RISC-V */
+        RISCV64,
+
         /**
          * Unknown CPU architecture.  A best effort will be made to infer architecture
          * specific values such as address and long size.
@@ -246,6 +249,8 @@ public abstract class Platform {
             return CPU.MIPS64EL;
         } else if (equalsIgnoreCase("loongarch64", archString)) {
            return CPU.LOONGARCH64;
+        } else if (equalsIgnoreCase("riscv64", archString)) {
+           return CPU.RISCV64;
         }
 
         // Try to find by lookup up in the CPU list
@@ -308,6 +313,7 @@ public abstract class Platform {
                 case AARCH64:
 		case MIPS64EL:
 		case LOONGARCH64:
+        case RISCV64:
                     dataModel = 64;
                     break;
                 default:

--- a/src/main/java/jnr/ffi/provider/jffi/platform/riscv64/linux/TypeAliases.java
+++ b/src/main/java/jnr/ffi/provider/jffi/platform/riscv64/linux/TypeAliases.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016 Wayne Meissner
+ *
+ * This file is part of the JNR project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jnr.ffi.provider.jffi.platform.riscv64.linux;
+
+import jnr.ffi.NativeType;
+import jnr.ffi.TypeAlias;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public final class TypeAliases {
+    public static final Map<TypeAlias, jnr.ffi.NativeType> ALIASES = buildTypeMap();
+    private static Map<TypeAlias, jnr.ffi.NativeType> buildTypeMap() {
+        Map<TypeAlias, jnr.ffi.NativeType> m = new EnumMap<TypeAlias, jnr.ffi.NativeType>(TypeAlias.class);
+        m.put(TypeAlias.int8_t, NativeType.SCHAR);
+        m.put(TypeAlias.u_int8_t, NativeType.UCHAR);
+        m.put(TypeAlias.int16_t, NativeType.SSHORT);
+        m.put(TypeAlias.u_int16_t, NativeType.USHORT);
+        m.put(TypeAlias.int32_t, NativeType.SINT);
+        m.put(TypeAlias.u_int32_t, NativeType.UINT);
+        m.put(TypeAlias.int64_t, NativeType.SLONG);
+        m.put(TypeAlias.u_int64_t, NativeType.ULONG);
+        m.put(TypeAlias.intptr_t, NativeType.SLONG);
+        m.put(TypeAlias.uintptr_t, NativeType.ULONG);
+        m.put(TypeAlias.caddr_t, NativeType.ADDRESS);
+        m.put(TypeAlias.dev_t, NativeType.ULONG);
+        m.put(TypeAlias.blkcnt_t, NativeType.SLONG);
+        m.put(TypeAlias.blksize_t, NativeType.SINT);
+        m.put(TypeAlias.gid_t, NativeType.UINT);
+        m.put(TypeAlias.in_addr_t, NativeType.UINT);
+        m.put(TypeAlias.in_port_t, NativeType.USHORT);
+        m.put(TypeAlias.ino_t, NativeType.ULONG);
+        m.put(TypeAlias.ino64_t, NativeType.ULONG);
+        m.put(TypeAlias.key_t, NativeType.SINT);
+        m.put(TypeAlias.mode_t, NativeType.UINT);
+        m.put(TypeAlias.nlink_t, NativeType.UINT);
+        m.put(TypeAlias.id_t, NativeType.UINT);
+        m.put(TypeAlias.pid_t, NativeType.SINT);
+        m.put(TypeAlias.off_t, NativeType.SLONG);
+        m.put(TypeAlias.swblk_t, NativeType.SLONG);
+        m.put(TypeAlias.uid_t, NativeType.UINT);
+        m.put(TypeAlias.clock_t, NativeType.SLONG);
+        m.put(TypeAlias.size_t, NativeType.ULONG);
+        m.put(TypeAlias.ssize_t, NativeType.SLONG);
+        m.put(TypeAlias.time_t, NativeType.SLONG);
+        m.put(TypeAlias.fsblkcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.fsfilcnt_t, NativeType.ULONG);
+        m.put(TypeAlias.sa_family_t, NativeType.USHORT);
+        m.put(TypeAlias.socklen_t, NativeType.UINT);
+        m.put(TypeAlias.rlim_t, NativeType.ULONG);
+        m.put(TypeAlias.cc_t, NativeType.UCHAR);
+        m.put(TypeAlias.speed_t, NativeType.UINT);
+        m.put(TypeAlias.tcflag_t, NativeType.UINT);
+        return m;
+    }
+}


### PR DESCRIPTION
Add riscv64 linux support referenced to other arches, tested under QEMU 7.0 virt machine. 

To verify various types, I used the following program. It seems that there is no `swblk_t` type in linux and I leave it same as aarch64.
```
#include <stdio.h>                                                                             
#include <stdint.h>                                                                            
#include <unistd.h>                                                                            
#include <stdlib.h>                                                                            
#include <netinet/in.h>                                                                        
#include <asm-generic/termbits.h>                                                              
#include <sys/resource.h>                                                                      
#define tYpeof(t)  _Generic(t,\                                                                
            int8_t: printf("i8\n"),\                                                           
            uint8_t: printf("u8\n"),\                                                          
            int16_t: printf("i16\n"),\
            uint16_t: printf("u16\n"),\                                                        
            int32_t: printf("i32\n"),\                                                         
            uint32_t: printf("u32\n"),\                                                        
            int64_t: printf("i64\n"),\                                                         
            uint64_t: printf("u64\n"),\                                                        
            char *: printf("char *\n"))                                                        
                                               
int main()                                                                                     
{                                                                                              
    { int8_t  a;printf("%20s","int8_t  ");tYpeof(a);}
    { u_int8_t  a;printf("%20s","u_int8_t  ");tYpeof(a);}
    { int16_t  a;printf("%20s","int16_t  ");tYpeof(a);}
    { u_int16_t  a;printf("%20s","u_int16_t  ");tYpeof(a);}  
    { int32_t  a;printf("%20s","int32_t  ");tYpeof(a);}      
    { u_int32_t  a;printf("%20s","u_int32_t  ");tYpeof(a);}    
    { int64_t  a;printf("%20s","int64_t  ");tYpeof(a);}    
    { u_int64_t  a;printf("%20s","u_int64_t  ");tYpeof(a);}
    { intptr_t  a;printf("%20s","intptr_t  ");tYpeof(a);}                                      
    { uintptr_t  a;printf("%20s","uintptr_t  ");tYpeof(a);}
    { caddr_t  a;printf("%20s","caddr_t  ");tYpeof(a);} 
    { dev_t  a;printf("%20s","dev_t  ");tYpeof(a);}
    { blkcnt_t  a;printf("%20s","blkcnt_t  ");tYpeof(a);}
    { blksize_t  a;printf("%20s","blksize_t  ");tYpeof(a);}
    { gid_t  a;printf("%20s","gid_t  ");tYpeof(a);}
    { in_addr_t  a;printf("%20s","in_addr_t  ");tYpeof(a);}
    { in_port_t  a;printf("%20s","in_port_t  ");tYpeof(a);}
    { ino_t  a;printf("%20s","ino_t  ");tYpeof(a);}
    { printf("%20s","ino64_t\n"); }
    { key_t  a;printf("%20s","key_t  ");tYpeof(a);}
    { mode_t  a;printf("%20s","mode_t  ");tYpeof(a);}
    { nlink_t  a;printf("%20s","nlink_t  ");tYpeof(a);}
    { id_t  a;printf("%20s","id_t  ");tYpeof(a);}
    { pid_t  a;printf("%20s","pid_t  ");tYpeof(a);}
    { off_t  a;printf("%20s","off_t  ");tYpeof(a);}
    { printf("%20s","swblk_t\n"); }
    { uid_t  a;printf("%20s","uid_t  ");tYpeof(a);}
    { clock_t  a;printf("%20s","clock_t  ");tYpeof(a);}
    { size_t  a;printf("%20s","size_t  ");tYpeof(a);}
    { ssize_t  a;printf("%20s","ssize_t  ");tYpeof(a);}
    { time_t  a;printf("%20s","time_t  ");tYpeof(a);}
    { fsblkcnt_t  a;printf("%20s","fsblkcnt_t  ");tYpeof(a);}
    { fsfilcnt_t  a;printf("%20s","fsfilcnt_t  ");tYpeof(a);}
    { sa_family_t  a;printf("%20s","sa_family_t  ");tYpeof(a);}
    { socklen_t  a;printf("%20s","socklen_t  ");tYpeof(a);}
    { rlim_t  a;printf("%20s","rlim_t  ");tYpeof(a);}
    { cc_t  a;printf("%20s","cc_t  ");tYpeof(a);}
    { speed_t  a;printf("%20s","speed_t  ");tYpeof(a);}
    { tcflag_t  a;printf("%20s","tcflag_t  ");tYpeof(a);}
}
```