### PR TITLE
Update jffi to 1.3.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,13 +61,13 @@
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.github.jnr</groupId>
       <artifactId>jffi</artifactId>
-      <version>1.3.12</version>
+      <version>1.3.13</version>
       <scope>runtime</scope>
       <classifier>native</classifier>
     </dependency>


### PR DESCRIPTION
Changes:

* Fixes the dependency on glibc 2.27 by disabling memfd_create (https://github.com/jnr/jffi/pull/138, https://github.com/jnr/jffi/pull/155).
* Uses Cleaner rather than finalization on JDKs that support it (https://github.com/jnr/jffi/pull/152).