### PR TITLE
Adapt pointer to closure

### DIFF
--- a/src/main/java/jnr/ffi/provider/ClosureManager.java
+++ b/src/main/java/jnr/ffi/provider/ClosureManager.java
@@ -24,4 +24,5 @@ package jnr.ffi.provider;
 public interface ClosureManager {
     public abstract <T> T newClosure(Class<? extends T> closureClass, T instance);
     public abstract <T> jnr.ffi.Pointer getClosurePointer(Class<? extends T> closureClass, T instance);
+    public abstract <T> T getClosureFromPointer(Class<? extends T> closureClass, jnr.ffi.Pointer pointer);
 }


### PR DESCRIPTION
When implementing an integration with the libfuse I noticed that the [readdir callback](https://github.com/libfuse/libfuse/blob/fuse-2.9.9/include/fuse.h#L283-L305) supplies the user with a [fuse_fill_dir_t](https://github.com/libfuse/libfuse/blob/fuse-2.9.9/include/fuse.h#L58-L59) that is a pointer to a function that supposed to be called for every child item in the directory.

I have not found a way to automatically nor programmatically convert that pointer to a closure so that it could be called within java.
I believe [others implementations](https://github.com/SerCeMan/jnr-fuse/blob/00750de4067d9aec8adba61f76965cca56c163a3/src/main/java/ru/serce/jnrfuse/AbstractFuseFS.java#L171-L176) might have a similar issue that required a [split package to fix](https://github.com/SerCeMan/jnr-fuse/blob/00750de4067d9aec8adba61f76965cca56c163a3/src/main/java/jnr/ffi/provider/jffi/ClosureHelper.java).

This change adds a similar implementation to the ClosureManager/NativeClosureManager so that the pointer could be adapted to the interface callable from java.

I am new to the `jnr-ffi` lib. Please let me know if I miss anything or if it is a right way to resolve this issue. 

Thanks! 