### PR TITLE
build(deps): downgrade JUnit to 5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>6.1.0</version>
+      <version>5.14.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
JUnit 6.x is only java 17+ compatible and goal here is to test against java 8 and 11 for now, causing matrix tests to fail.